### PR TITLE
Add code sniffer/fixer targets to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,3 +100,10 @@ devel:
 	-docker-compose exec php drush cr
 	@make -s chown
 
+phpcs:
+	docker run --rm -v $(shell pwd)/src/$(PROFILE_NAME):/work skilldlabs/docker-phpcs-drupal phpcs --standard=Drupal --extensions=php,module,inc,install,test,profile,theme,info .
+	docker run --rm -v $(shell pwd)/src/$(PROFILE_NAME):/work skilldlabs/docker-phpcs-drupal phpcs --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme,info .
+
+phpcbf:
+	docker run --rm -v $(shell pwd)/src/$(PROFILE_NAME):/work skilldlabs/docker-phpcs-drupal phpcbf --standard=Drupal --extensions=php,module,inc,install,test,profile,theme,info .
+	docker run --rm -v $(shell pwd)/src/$(PROFILE_NAME):/work skilldlabs/docker-phpcs-drupal phpcbf --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme,info .

--- a/README.md
+++ b/README.md
@@ -57,3 +57,5 @@ For Linux install <a href="https://docs.docker.com/compose/install/" target="_bl
 * `make chown` - Change permissions inside container. Use it in case you can not access files in _build_. folder from your machine.
 * `make exec` - docker exec into php container.
 * `make devel` - Devel + kint setup, and config for Twig debug mode.
+* `make phpcs` - check codebase with `phpcs` sniffers to make sure it conforms https://www.drupal.org/docs/develop/standards.
+* `make phpcbf` - fix codebase according to Drupal standards https://www.drupal.org/docs/develop/standards.


### PR DESCRIPTION
Now backenders can use `make phpcs` & `make phpcbf`

Closes #24 