### PR TITLE
Use nproc to speed drush make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ install:
 
 reinstall:
 	cp src/drush_make/*.make.yml build/
-	docker-compose exec php drush make profile.make.yml --prepare-install --overwrite -y; \
+	docker-compose exec php drush make profile.make.yml --concurrency=$(shell nproc) --prepare-install --overwrite -y; \
 	rm build/*.make.yml; \
 	docker-compose exec php composer global require "hirak/prestissimo:^0.3"; \
 	docker-compose exec php composer config repositories.drupal composer https://packages.drupal.org/8; \


### PR DESCRIPTION
I got this numbers

```
time drush make --no-core profile.make.yml .
real    0m 45.29s
user    0m 12.16s
sys 0m 3.98s

time drush make --no-core --concurrency=2 profile.make.yml .
real    0m 32.02s
user    0m 13.04s
sys 0m 4.20s

time drush make --no-core --concurrency=4 profile.make.yml .
real    0m 25.59s
user    0m 14.16s
sys 0m 4.40s

time drush make --no-core --concurrency=8 profile.make.yml .
real    0m 22.39s
user    0m 16.39s
sys 0m 4.54s
```