### PR TITLE
Colored Output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ endif
 
 front:
 	@echo "Building front tasks..."
-	docker run -ti --rm -v $(shell pwd)/src/themes/$(THEME_NAME):/work skilldlabs/frontend:zen; \
+	docker run -t --rm -v $(shell pwd)/src/themes/$(THEME_NAME):/work skilldlabs/frontend:zen; \
 	docker-compose exec php rm -rf themes/custom/$(THEME_NAME)/node_modules
 	make -s chown
 

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ endif
 
 front:
 	@echo "Building front tasks..."
-	docker run --rm -v $(shell pwd)/src/themes/$(THEME_NAME):/work skilldlabs/frontend:zen; \
+	docker run -ti --rm -v $(shell pwd)/src/themes/$(THEME_NAME):/work skilldlabs/frontend:zen; \
 	docker-compose exec php rm -rf themes/custom/$(THEME_NAME)/node_modules
 	make -s chown
 


### PR DESCRIPTION
Added support for npm colored output, tested and works ok, but for composer/php it wasn't that easy, I know that it at least requires this to work:

for npm colored output

* just `-t` flag to allocate a terminal and `-i` for interactive

for composer colored output

* install php-posix (php7-posix or the correct name)
* source /etc/profile
* add `TERM=xterm-256color` and `tty: true` to `docker-compose.yml`
* probably something else here that's missing