### PR TITLE
Fix .env escaping&formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ front:
 	make -s chown
 
 iprange:
-	$(shell grep -q -F 'IPRANGE=' .env || echo "\nIPRANGE=$(shell docker network inspect $(COMPOSE_PROJECT_NAME)_front --format '{{(index .IPAM.Config 0).Subnet}}')" >> .env)
+	$(shell grep -q -F 'IPRANGE=' .env || printf "\nIPRANGE=$(shell docker network inspect $(COMPOSE_PROJECT_NAME)_front --format '{{(index .IPAM.Config 0).Subnet}}')" >> .env)
 
 devel:
 	@echo "Setting up permissions ..."


### PR DESCRIPTION
Fixes an issue where the `.env` file is created with a `\n` and breaks the build

as an alternative `echo -e` would work too