### PR TITLE
MacOS shared folder config + cached option

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -6,3 +6,4 @@ SITE_NAME=Site name
 COMPOSER_REQUIRE=solarium/solarium:3.6.*
 PROJECT_INSTALL=
 PHP_VERSION=7.1
+SHARED_FOLDER=/dev/shm

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 
 build: clean
 	mkdir -p build
-	mkdir -p /dev/shm/${COMPOSE_PROJECT_NAME}_mysql
+	mkdir -p ${SHARED_FOLDER}/${COMPOSE_PROJECT_NAME}_mysql
 
 install:
 	@echo "Updating containers..."

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ For Linux install <a href="https://docs.docker.com/compose/install/" target="_bl
 
 5\. Run `make`
 
+Additional steps for MacOS install: (https://docs.docker.com/docker-for-mac/osxfs-caching/)
+
+  2\.4\. Set SHARED_FOLDER variable to any writable absolute path instead of /dev/shm (PROJECT_PATH/sql for example)
+
+3\. Copy __docker-compose\.override\.yml\.default_mac__ to __docker-compose\.override\.yml__
+
 ## Usage
 
 * `make` - Install project.

--- a/src/docker/docker-compose.override.yml.default_mac
+++ b/src/docker/docker-compose.override.yml.default_mac
@@ -1,0 +1,44 @@
+version: "2"
+
+services:
+
+# Override base service.
+  php:
+    volumes:
+      - ../../build:/var/www/html:cached
+      - ../${PROFILE_NAME}:/var/www/html/profiles/${PROFILE_NAME}:cached
+      - ../modules:/var/www/html/modules/custom:cached
+      - ../themes:/var/www/html/themes/custom:cached
+      - "./90-mail.ini:/etc/php${PHP_VERSION}/conf.d/90-mail.ini:cached"
+      - ../../config/sync:/var/www/html/sync:cached
+# Uncomment next line if you need PHP XDebug.
+#    command: php-fpm7 -F -d zend_extension=xdebug.so
+
+#  adminer:
+#    image: dockette/adminer:mysql-php7
+#    container_name: "${COMPOSE_PROJECT_NAME}_adminer"
+#    links:
+#      - mysql:mysql
+#    depends_on:
+#      - mysql
+#    networks:
+#      - front
+
+  mailhog:
+    image: skilldlabs/mailhog
+    container_name: "${COMPOSE_PROJECT_NAME}_mail"
+    restart: always
+    networks:
+      - front
+
+  mysql:
+    volumes:
+      - ${SHARED_FOLDER}/${COMPOSE_PROJECT_NAME}_mysql:/var/lib/mysql:cached
+
+
+  nginx:
+    ports:
+      - "8086:80"
+# Mount local folder with ssl keys.
+#    volumes:
+#     - ./nginx/ssl:/etc/nginx/ssl:Z

--- a/src/docker/docker-compose.yml
+++ b/src/docker/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     image: percona:5.7
     container_name: "${COMPOSE_PROJECT_NAME}_mysql"
     volumes:
-      - /dev/shm/${COMPOSE_PROJECT_NAME}_mysql:/var/lib/mysql:Z
+      - ${SHARED_FOLDER}/${COMPOSE_PROJECT_NAME}_mysql:/var/lib/mysql:Z
     environment:
       MYSQL_DATABASE: d8
       MYSQL_USER: d8


### PR DESCRIPTION
Two things done here:

1. Changed shared folder location. Now it is env variable.
2. Added macOS composer override file. To use cached option in volumes: https://docs.docker.com/docker-for-mac/osxfs-caching/