### PR TITLE
Update drush

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
     "drupal/styleguide": "^1",
     "drupal/swiftmailer": "^1",
     "drupal/token": "^1",
+    "drush/drush": "^9.6",
     "webflo/drupal-finder": "^1.1",
     "webmozart/path-util": "^2.3",
     "wikimedia/composer-merge-plugin": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,7 @@
     "composer-exit-on-patch-failure": true,
     "patches": {
       "drupal/core": {
-        "Setting required on radios marks all options required": "https://www.drupal.org/files/issues/2018-10-09/2731991-34.patch",
+        "Setting required on radios marks all options required": "https://www.drupal.org/files/issues/2019-03-19/2731991-38.patch",
         "Programmatically created translatable content type returns SQL error on content creation": "https://www.drupal.org/files/issues/2018-10-06/2599228-74.patch"
       },
       "drupal/default_content": {


### PR DESCRIPTION
### Action

When updating .env file with PROJECT_INSTALL=config, then command from Makefile fails : 
`drush si config_installer --db-url=$(DB_URL) --account-pass=admin -y config_installer_sync_configure_form.sync_directory=../config/sync)`

### Observed result

Issue is solved by using Drush 9.6+



### Todo

Update drush version from composer


