### PR TITLE
Make info update : Added prefix + exposed traefik port + filtered exposed containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,8 @@ endif
 ## Project's containers information
 info:
 	$(info Containers for "$(COMPOSE_PROJECT_NAME)" info:)
-	$(eval CONTAINERS = $(shell docker ps -f name=$(COMPOSE_PROJECT_NAME) --format "{{ .ID }}"))
-	$(foreach CONTAINER, $(CONTAINERS),$(info $(shell printf '%-19s \n'  $(shell docker inspect --format='{{.NetworkSettings.Networks.$(COMPOSE_NET_NAME).IPAddress}} {{range $$p, $$conf := .NetworkSettings.Ports}}{{$$p}}{{end}} {{.Name}}' $(CONTAINER) | rev | sed "s/pct\//,pct:/g" | sed "s/,//" | rev | awk '{ print $0}')) ))
+	$(eval CONTAINERS = $(shell docker ps -f name=$(COMPOSE_PROJECT_NAME) --format "{{ .ID }}" -f 'label=traefik.enable=true'))
+	$(foreach CONTAINER, $(CONTAINERS),$(info http://$(shell printf '%-19s \n'  $(shell docker inspect --format='{{.NetworkSettings.Networks.$(COMPOSE_NET_NAME).IPAddress}}:{{index .Config.Labels "traefik.port"}} {{range $$p, $$conf := .NetworkSettings.Ports}}{{$$p}}{{end}} {{.Name}}' $(CONTAINER) | rev | sed "s/pct\//,pct:/g" | sed "s/,//" | rev | awk '{ print $0}')) ))
 	@echo "$(RESULT)"
 
 ## Run shell in PHP container as regular user


### PR DESCRIPTION

### Action

- make all
- make info


### Observed result
- `make info` is 
   - listing all containers IP, whether they are exposed or not
   - missing http prefix to IPs, making it inconfortable to open in browser
   - missing container port exposed by traefik, making it inconfortable to read non default ports

### Expected result
- `make info` can be slightly updated to fix these issues 



### Todo

- Update `make info`



