### PR TITLE
Adding git pre-commit hook to validate lang code of base config files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ phpcsexec = docker run --rm \
 	--ignore=*.css,libraries/*,dist/*,styleguide/* \
 	.
 
+$(info Installing git hooks)
+$(shell ln -sfn ../../scripts/git_hooks/pre-commit.sh .git/hooks/pre-commit)
+
 ## Full site install from the scratch
 all: | provision composer si info
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ networks:
 
 * Use our <a href="https://github.com/skilld-labs/skilld-docker-container/issues">issue queue</a>, which is public, to search or add new issues.  
 
+## Git hooks
+
+* Project includes pre-commit [git hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) to perform automatic checks when `git commit` is executed
+* You can bypass these checks by running `git commit --no-verify`
+
 ## License
 
 This project is licensed under the MIT open source license.

--- a/scripts/git_hooks/pre-commit.sh
+++ b/scripts/git_hooks/pre-commit.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+
+# pre-commit.sh
+STASH_NAME="pre-commit-$(date +%s)"
+git stash save -q --keep-index $STASH_NAME
+
+# Bold and normal formating
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+# langcode logic
+if [ -r config/sync/*.system.site.yml ]
+then
+	printf "\n*.system.site.yml file exists\n"
+
+	# Display the site settings config file (if it exists) + save it in a variable
+	SITE_SETTINGS_FILE_PATH=$(find config/sync -type f -name "*.system.site.yml")
+	printf "Its path is : $SITE_SETTINGS_FILE_PATH\n"
+
+	# Display Drupal default language as defined in the site settings config file + save it in a variable
+	DEFAULT_SITE_LANG_VALUE=$(awk -v pattern="default_langcode" '$1 ~ pattern { print $NF }' config/sync/*.system.site.yml)
+	printf "Default site language is : \e[32m$DEFAULT_SITE_LANG_VALUE\e[0m\n\n"
+
+	# Display the language defined in each of the basic config files + save them in a variable
+	LANG_VALUE_IN_BASE_CONFIG_FILES=$(awk '$1 ~ /^langcode/ { print $NF }' config/sync/*.yml | grep -wE '\w{1,2}' | sort | uniq)
+	#printf "LANG_VALUE_IN_BASE_CONFIG_FILES :\n$LANG_VALUE_IN_BASE_CONFIG_FILES\n\n"
+
+	# NAME_OF_BASE_CONFIG_FILES=$(grep -R 'langcode' config/sync/*.yml -l)
+	#printf "NAME_OF_BASE_CONFIG_FILES :\n$NAME_OF_BASE_CONFIG_FILES\n\n"
+
+	printf "\e[33mChecking lang for each file...\e[0m\n"
+	# Defining value of MESSAGE_OUTPUT variable
+	MESSAGE_OUTPUT="\n${bold}The language of some base config files is NOT matching site default language ${normal}(\e[32m$DEFAULT_SITE_LANG_VALUE\e[0m) :"
+	FAIL=0
+
+	# For each file, compare the language of base config files against default site language
+	for lang in $LANG_VALUE_IN_BASE_CONFIG_FILES; do
+		if [ "$lang" != "$DEFAULT_SITE_LANG_VALUE" ]
+		then
+			FAIL=1
+			MESSAGE_OUTPUT="$MESSAGE_OUTPUT \n${bold} - langcode \e[31m$lang\e[0m ${bold}was found in $(grep -R "langcode: $lang" config/sync/*.yml -l | wc -l) file(s)${normal}\n$(grep -R "langcode: $lang" config/sync/*.yml -l)"
+		fi
+	done
+	if [ $FAIL -eq 1 ]
+	then
+		echo "$MESSAGE_OUTPUT \n\n\e[33mBase configs should always be in same language as default site language.\e[0m\n\n${bold}\e[31mCOMMIT REJECTED!${normal}\e[0m\n"
+	else
+		echo "\e[33mLangage of all base config files is matching default site language. You are good to go!\e[0m\n"
+	fi
+	exit $FAIL
+else
+	echo "*.system.site.yml file does not exist"
+	exit 1
+fi
+
+# post-commit.sh
+STASHES=$(git stash list)
+if [[ $STASHES == "$STASH_NAME" ]]; then
+  git stash pop -q
+fi

--- a/scripts/git_hooks/pre-commit.sh
+++ b/scripts/git_hooks/pre-commit.sh
@@ -9,16 +9,16 @@ bold=$(tput bold)
 normal=$(tput sgr0)
 
 # langcode logic
-if [ -r config/sync/*.system.site.yml ]
+if [ -r config/sync/system.site.yml ]
 then
-	printf "\n*.system.site.yml file exists\n"
+	printf "\nsystem.site.yml file exists\n"
 
 	# Display the site settings config file (if it exists) + save it in a variable
-	SITE_SETTINGS_FILE_PATH=$(find config/sync -type f -name "*.system.site.yml")
+	SITE_SETTINGS_FILE_PATH=$(find config/sync -type f -name "system.site.yml")
 	printf "Its path is : $SITE_SETTINGS_FILE_PATH\n"
 
 	# Display Drupal default language as defined in the site settings config file + save it in a variable
-	DEFAULT_SITE_LANG_VALUE=$(awk -v pattern="default_langcode" '$1 ~ pattern { print $NF }' config/sync/*.system.site.yml)
+	DEFAULT_SITE_LANG_VALUE=$(awk -v pattern="default_langcode" '$1 ~ pattern { print $NF }' config/sync/system.site.yml)
 	printf "Default site language is : \e[32m$DEFAULT_SITE_LANG_VALUE\e[0m\n\n"
 
 	# Display the language defined in each of the basic config files + save them in a variable
@@ -43,14 +43,14 @@ then
 	done
 	if [ $FAIL -eq 1 ]
 	then
-		echo "$MESSAGE_OUTPUT \n\n\e[33mBase configs should always be in same language as default site language.\e[0m\n\n${bold}\e[31mCOMMIT REJECTED!${normal}\e[0m\nTo bypass validation, use git commit --no-verify\n""
+		echo "$MESSAGE_OUTPUT \n\n\e[33mBase configs should always be in same language as default site language.\e[0m\n\n${bold}\e[31mCOMMIT REJECTED!${normal}\e[0m\nTo bypass validation, use git commit --no-verify\n"
 	else
 		echo "\e[33mLangage of all base config files is matching default site language. You are good to go!\e[0m\n"
 	fi
 	exit $FAIL
 else
-	echo "*.system.site.yml file does not exist"
-	exit 1
+	echo "system.site.yml file does not exist, nothing to check here"
+	exit 0
 fi
 
 # post-commit.sh

--- a/scripts/git_hooks/pre-commit.sh
+++ b/scripts/git_hooks/pre-commit.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env sh
 
-# pre-commit.sh
-STASH_NAME="pre-commit-$(date +%s)"
-git stash save -q --keep-index $STASH_NAME
-
 # Bold and normal formating
 bold=$(tput bold)
 normal=$(tput sgr0)
 
-# langcode logic
+# Checking langcode of base config files
 if [ -r config/sync/system.site.yml ]
 then
 	printf "\nsystem.site.yml file exists\n"
@@ -51,10 +47,4 @@ then
 else
 	echo "system.site.yml file does not exist, nothing to check here"
 	exit 0
-fi
-
-# post-commit.sh
-STASHES=$(git stash list)
-if [[ $STASHES == "$STASH_NAME" ]]; then
-  git stash pop -q
 fi

--- a/scripts/git_hooks/pre-commit.sh
+++ b/scripts/git_hooks/pre-commit.sh
@@ -19,10 +19,6 @@ then
 
 	# Display the language defined in each of the basic config files + save them in a variable
 	LANG_VALUE_IN_BASE_CONFIG_FILES=$(awk '$1 ~ /^langcode/ { print $NF }' config/sync/*.yml | grep -wE '\w{1,2}' | sort | uniq)
-	#printf "LANG_VALUE_IN_BASE_CONFIG_FILES :\n$LANG_VALUE_IN_BASE_CONFIG_FILES\n\n"
-
-	# NAME_OF_BASE_CONFIG_FILES=$(grep -R 'langcode' config/sync/*.yml -l)
-	#printf "NAME_OF_BASE_CONFIG_FILES :\n$NAME_OF_BASE_CONFIG_FILES\n\n"
 
 	printf "\e[33mChecking lang for each file...\e[0m\n"
 	# Defining value of MESSAGE_OUTPUT variable

--- a/scripts/git_hooks/pre-commit.sh
+++ b/scripts/git_hooks/pre-commit.sh
@@ -7,20 +7,16 @@ normal=$(tput sgr0)
 # Checking langcode of base config files
 if [ -r config/sync/system.site.yml ]
 then
-	printf "\nsystem.site.yml file exists\n"
 
-	# Display the site settings config file (if it exists) + save it in a variable
+	# Get the site settings config file (if it exists) + save it in a variable
 	SITE_SETTINGS_FILE_PATH=$(find config/sync -maxdepth 1 -type f -name "system.site.yml")
-	printf "Its path is : $SITE_SETTINGS_FILE_PATH\n"
 
-	# Display Drupal default language as defined in the site settings config file + save it in a variable
+	# Get Drupal default language as defined in the site settings config file + save it in a variable
 	DEFAULT_SITE_LANG_VALUE=$(awk -v pattern="default_langcode" '$1 ~ pattern { print $NF }' config/sync/system.site.yml)
-	printf "Default site language is : \e[32m$DEFAULT_SITE_LANG_VALUE\e[0m\n\n"
 
-	# Display the language defined in each of the basic config files + save them in a variable
+	# Get the language defined in each of the basic config files + save them in a variable
 	LANG_VALUE_IN_BASE_CONFIG_FILES=$(awk '$1 ~ /^langcode/ { print $NF }' config/sync/*.yml | grep -wE '\w{1,2}' | sort | uniq)
 
-	printf "\e[33mChecking lang for each file...\e[0m\n"
 	# Defining value of MESSAGE_OUTPUT variable
 	MESSAGE_OUTPUT="\n${bold}The language of some base config files is NOT matching site default language ${normal}(\e[32m$DEFAULT_SITE_LANG_VALUE\e[0m) :"
 	FAIL=0
@@ -30,17 +26,12 @@ then
 		if [ "$lang" != "$DEFAULT_SITE_LANG_VALUE" ]
 		then
 			FAIL=1
-			MESSAGE_OUTPUT="$MESSAGE_OUTPUT \n${bold} - langcode \e[31m$lang\e[0m ${bold}was found in $(grep -R "langcode: $lang" config/sync/*.yml -l | wc -l) file(s)${normal}\n$(grep -R "langcode: $lang" config/sync/*.yml -l)"
+			MESSAGE_OUTPUT="$MESSAGE_OUTPUT \n${bold} - langcode \e[31m$lang\e[0m ${bold}was found in $(grep -Re "^langcode: $lang" config/sync/*.yml -l | wc -l) file(s)${normal}\n$(grep -Re "^langcode: $lang" config/sync/*.yml -l)"
 		fi
 	done
 	if [ $FAIL -eq 1 ]
 	then
-		echo "$MESSAGE_OUTPUT \n\n\e[33mBase configs should always be in same language as default site language.\e[0m\n\n${bold}\e[31mCOMMIT REJECTED!${normal}\e[0m\nTo bypass validation, use git commit --no-verify\n"
-	else
-		echo "\e[33mLangage of all base config files is matching default site language. You are good to go!\e[0m\n"
+		echo "$MESSAGE_OUTPUT \n\n\e[33mBase configs should always be in same language as default site language.\e[0m\n\n${bold}\e[31mCOMMIT REJECTED!${normal}\e[0m\n"
 	fi
 	exit $FAIL
-else
-	echo "system.site.yml file does not exist, nothing to check here"
-	exit 0
 fi

--- a/scripts/git_hooks/pre-commit.sh
+++ b/scripts/git_hooks/pre-commit.sh
@@ -14,7 +14,7 @@ then
 	printf "\nsystem.site.yml file exists\n"
 
 	# Display the site settings config file (if it exists) + save it in a variable
-	SITE_SETTINGS_FILE_PATH=$(find config/sync -type f -name "system.site.yml")
+	SITE_SETTINGS_FILE_PATH=$(find config/sync -maxdepth 1 -type f -name "system.site.yml")
 	printf "Its path is : $SITE_SETTINGS_FILE_PATH\n"
 
 	# Display Drupal default language as defined in the site settings config file + save it in a variable

--- a/scripts/git_hooks/pre-commit.sh
+++ b/scripts/git_hooks/pre-commit.sh
@@ -43,7 +43,7 @@ then
 	done
 	if [ $FAIL -eq 1 ]
 	then
-		echo "$MESSAGE_OUTPUT \n\n\e[33mBase configs should always be in same language as default site language.\e[0m\n\n${bold}\e[31mCOMMIT REJECTED!${normal}\e[0m\n"
+		echo "$MESSAGE_OUTPUT \n\n\e[33mBase configs should always be in same language as default site language.\e[0m\n\n${bold}\e[31mCOMMIT REJECTED!${normal}\e[0m\nTo bypass validation, use git commit --no-verify\n""
 	else
 		echo "\e[33mLangage of all base config files is matching default site language. You are good to go!\e[0m\n"
 	fi


### PR DESCRIPTION
### Action

1. Clone and make an existing project locally
2. Login with an admin user whose language is set to FR
3. Edit and save a config using admin UI in FR
4. make cex

### Observed result

- Configs which were updated in FR language are exported to /config/sync/ in FR language, replacing original EN config
- This is in contradiction of skilld practice to always keep config in EN language then translate it (ex : /config/sync/language/fr/)

### Expected result

- We sould always keep config in EN language then translate it to other languages (ex : /config/sync/language/fr/)
- We should identify when base config are changing from EN to another lang


### Todo

- Implement a git pre-commit hook to validate langcode of base config files https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
