### PR TITLE
Adding watchdog validation target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,11 @@ compval:
 	@echo "Composer.json validation..."
 	@$(call php, composer validate --strict)
 
+watchdogval:
+	@echo "Watchdog validation..."
+	@$(call php, /bin/sh ./scripts/makefile/watchdog-validation.sh)
+
 
 ## Full inspection
-insp: | phpcs clang cinsp compval
+insp: | phpcs clang cinsp compval watchdogval
 

--- a/scripts/makefile/watchdog-validation.sh
+++ b/scripts/makefile/watchdog-validation.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+# Define messages to watch for
+## Separate with pipe : |
+## Possible values : Emergency|Alert|Critical|Error|Warning|Notice|Info|Debug
+MESSAGES_SEVERITY="Emergency|Alert|Critical|Error"
+
+# Get count of watchlog logs
+LOG_COUNT=$(drush watchdog-show --filter="severity~=#($MESSAGES_SEVERITY)#" --format=string | wc -l)
+
+# Exit1 and alert if logs
+if [[ "$LOG_COUNT" -gt "0" ]]; then
+	printf "The are \033[1m$LOG_COUNT messages\033[0m in logs to fix :\n"
+	drush watchdog-show --filter="severity~=#($MESSAGES_SEVERITY)#" --format=string
+	exit 1
+else
+	exit 0
+fi


### PR DESCRIPTION

### Observed result

- When errors are catched by and listed in watchdog, they don't always get identified and acted upon right away



### Expected result

- Makefile could contain a target to run a check of whatchdog logs


### Todo

1. Implement script using drush commandI
2. Implement new make target `watchdogval`
3. Add new make target `watchdogval` to global validation target `make insp`
