### PR TITLE
Refactor composer validation target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,9 @@ cinsp:
 ## Validate composer.json file
 compval:
 	@echo "Composer.json validation..."
-	@$(call php, composer validate --strict)
+	@$(call php, /bin/sh ./scripts/makefile/composer-validation.sh)
+
+
 
 watchdogval:
 	@echo "Watchdog validation..."

--- a/scripts/makefile/composer-validation.sh
+++ b/scripts/makefile/composer-validation.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+# Get command result
+COMMAND=$(composer validate --strict)
+
+# Exit1 and alert if not ok, otherwise remain silent
+if [[ "$COMMAND" != "./composer.json is valid" ]]; then
+	composer validate --strict
+	exit 1
+else
+	exit 0
+fi


### PR DESCRIPTION

### Action

`make compval`


### Observed result

```Composer.json validation...
./composer.json is valid
```
- Command is echoing string _./composer.json is valid_ when validation is successful

### Expected result

```Composer.json validation...
./composer.json is valid
```
- Command should not echo string _./composer.json is valid_ when validation is successful but still echo output if unsuccesful

### Todo

- Move composer command to dedicated script
- Update `make compval` target


