### PR TITLE
Adding mglaman/drupal-check validation target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Add utility functions and scripts to the container
 include scripts/makefile/*.mk
 
-.PHONY: all provision si exec exec0 down clean dev info phpcs phpcbf drush cinsp hooksymlink validation clang compval watchdogval
+.PHONY: all provision si exec exec0 down clean dev info phpcs phpcbf drush cinsp hooksymlink validation clang compval watchdogval drupalcheckval
 .DEFAULT_GOAL := help
 
 # https://stackoverflow.com/a/6273809/1826109
@@ -199,6 +199,16 @@ else
 	@echo "scripts/makefile/watchdog-validation.sh file does not exist"
 endif
 
+
+## Validate drupal-check
+drupalcheckval:
+ifneq ("$(wildcard scripts/makefile/drupal-check-validation.sh)","")
+	@echo "Drupal-check validation..."
+	@$(call php, /bin/sh ./scripts/makefile/drupal-check-validation.sh)
+else
+	@echo "scripts/makefile/drupal-check-validation.sh file does not exist"
+endif
+
 ## Full inspection
-validation: | phpcs clang cinsp compval watchdogval
+validation: | phpcs clang cinsp compval watchdogval drupalcheckval
 

--- a/scripts/makefile/drupal-check-validation.sh
+++ b/scripts/makefile/drupal-check-validation.sh
@@ -5,7 +5,7 @@
 LATEST_RELEASE_VERSION_URL=$(curl --silent "https://api.github.com/repos/mglaman/drupal-check/releases/latest" | grep "browser_download_url" | sed -E 's/.*"([^"]+)".*/\1/')
 
 # Define directory to scan recursively
-DIRECTORY_TO_SCAN="web/modules/custom"
+DIRECTORY_TO_SCAN="web/modules/custom/"
 
 # Get command result count
 COMMAND_COUNT=$(curl -s -O -L $LATEST_RELEASE_VERSION_URL \

--- a/scripts/makefile/drupal-check-validation.sh
+++ b/scripts/makefile/drupal-check-validation.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# curl and rm command should be removed in favor of composer when https://github.com/mglaman/drupal-check/issues/38 is fixed
+
+# Get latest release version url
+LATEST_RELEASE_VERSION_URL=$(curl --silent "https://api.github.com/repos/mglaman/drupal-check/releases/latest" | grep "browser_download_url" | sed -E 's/.*"([^"]+)".*/\1/')
+
+# Define directory to scan recursively
+DIRECTORY_TO_SCAN="web/modules/custom"
+
+# Get command result count
+COMMAND_COUNT=$(curl -s -O -L $LATEST_RELEASE_VERSION_URL \
+    && chmod +x drupal-check.phar \
+    && ./drupal-check.phar -ad -vv -n --no-progress $DIRECTORY_TO_SCAN --format=raw | wc -l)
+
+# Exit1 and alert if not ok, otherwise remain silent
+if [[ "$COMMAND_COUNT" -gt "0" ]]; then
+	printf "The are \033[1m$COMMAND_COUNT issues\033[0m detected by drupal-check to fix :\n"
+	./drupal-check.phar -ad -vv -n --no-progress $DIRECTORY_TO_SCAN
+	rm drupal-check.phar
+	exit 1
+else
+	rm drupal-check.phar
+	exit 0
+fi


### PR DESCRIPTION
- Curl method should be removed in favor of composer update when https://github.com/mglaman/drupal-check/issues/38 is fixed

- In the meantime, LATEST_RELEASE_VERSION_URL variable allows to always download latest release version of package 