### PR TITLE
Moving config_inspector to composer dev

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -132,7 +132,7 @@ test:cinsp:
   - pwd
   - ls -lah
   - ls -lah scripts/makefile/
-  - make drush config:inspect
+  - make cinsp
   tags:
   - review-apps-3
   dependencies:

--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,7 @@ endif
 cinsp:
 ifneq ("$(wildcard scripts/makefile/config-inspector-validation.sh)","")
 	@echo "Config schema validation..."
+	$(call php, composer install -o)
 	@$(call php, /bin/sh ./scripts/makefile/config-inspector-validation.sh)
 else
 	@echo "scripts/makefile/config-inspector-validation.sh file does not exist"

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
     "drupal-composer/drupal-scaffold": "^2.5",
     "drupal/admin_toolbar": "^1",
     "drupal/components": "^1",
-    "drupal/config_inspector": "^1.0@beta",
     "drupal/config_installer": "^1",
     "drupal/core": "^8.6.7",
     "drupal/default_content": "^1",
@@ -51,6 +50,7 @@
   },
   "require-dev": {
     "behat/behat": "^3.5",
+    "drupal/config_inspector": "^1.0@beta",
     "drupal/drupal-extension": "^3.4"
   },
   "conflict": {

--- a/scripts/makefile/config-inspector-validation.sh
+++ b/scripts/makefile/config-inspector-validation.sh
@@ -11,5 +11,6 @@ if [ "$ERROR_COUNT" -gt "0" ]; then
 	drush config:inspect --only-error
 	exit 1
 else
+	echo -e "Configuration is valid"
 	exit 0
 fi

--- a/scripts/makefile/watchdog-validation.sh
+++ b/scripts/makefile/watchdog-validation.sh
@@ -14,5 +14,6 @@ if [ "$LOG_COUNT" -gt "0" ]; then
 	drush watchdog-show --filter="severity~=#($MESSAGES_SEVERITY)#" --format=string
 	exit 1
 else
+	echo -e "Watchdog is valid : No message of high severity in logs ($MESSAGES_SEVERITY)"
 	exit 0
 fi


### PR DESCRIPTION
### Changes

- Moving config_inspector to composer dev
- Updating Makefile and Gitlab CI target cisnp
- Adding a message in scripts/makefile/config-inspector-validation.sh to display when test is succesful
- Adding a message in scripts/makefile/watchdog-validation.sh to display when test is succesful
