### PR TITLE
Update modules list in .env.default

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,7 +1,7 @@
 COMPOSE_FILE=./docker/docker-compose.yml:./docker/docker-compose.override.yml
 COMPOSE_PROJECT_NAME=projectname
 PROFILE_NAME=sdd
-MODULES=project_default_content
+MODULES=project_default_content better_normalizers default_content hal serialization
 THEME_NAME=
 SITE_NAME=Example
 SITE_MAIL=admin@example.com


### PR DESCRIPTION
`MODULES` parameter should include the complete list of dependencies for `project_default_content` module so we don't leave them enabled after importing the content