### PR TITLE
Adding panels config and modules to sdd profile + removing outdated patches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,10 @@
     "drupal/core": "^8.6.7",
     "drupal/default_content": "^1",
     "drupal/file_entity": "^2",
+    "drupal/manage_display": "^1.0@alpha",
+    "drupal/page_manager": "^4.0@beta",
     "drupal/panelbutton": "^1",
+    "drupal/panels_everywhere": "^4.0@beta",
     "drupal/styleguide": "^1",
     "drupal/swiftmailer": "^1",
     "drupal/token": "^1",
@@ -111,14 +114,8 @@
       "drupal/default_content": {
         "Do not reimport existing entities": "https://www.drupal.org/files/issues/do_not_reimport-2698425-56.patch"
       },
-      "drupal/devel": {
-        "Generate translated content with devel": "https://www.drupal.org/files/issues/2019-09-11/devel-generate-translated-content-1277654-53.patch"
-      },
       "drupal/config_inspector": {
         "Adds Drush 9 support to module command": "https://www.drupal.org/files/issues/2019-04-12/3047418-7.patch"
-      },
-      "genesis/behat-fail-aid": {
-        "Support image screenshot for drivers other than Selenium2Driver": "https://patch-diff.githubusercontent.com/raw/forceedge01/behat-fail-aid/pull/14-1.patch"
       }
     }
   }

--- a/web/profiles/sdd/config/install/core.entity_form_display.media.audio.default.yml
+++ b/web/profiles/sdd/config/install/core.entity_form_display.media.audio.default.yml
@@ -5,8 +5,14 @@ dependencies:
     - field.field.media.audio.field_media_file
     - media.type.audio
   module:
+    - field_layout
     - file
+    - layout_discovery
     - path
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.audio.default
 targetEntityType: media
 bundle: audio
@@ -53,6 +59,11 @@ content:
     weight: 100
     region: content
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5

--- a/web/profiles/sdd/config/install/core.entity_form_display.media.audio.media_library.yml
+++ b/web/profiles/sdd/config/install/core.entity_form_display.media.audio.media_library.yml
@@ -5,11 +5,23 @@ dependencies:
     - core.entity_form_mode.media.media_library
     - field.field.media.audio.field_media_file
     - media.type.audio
+  module:
+    - field_layout
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.audio.media_library
 targetEntityType: media
 bundle: audio
 mode: media_library
-content: {  }
+content:
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_media_file: true

--- a/web/profiles/sdd/config/install/core.entity_form_display.media.document.default.yml
+++ b/web/profiles/sdd/config/install/core.entity_form_display.media.document.default.yml
@@ -5,8 +5,14 @@ dependencies:
     - field.field.media.document.field_media_file
     - media.type.document
   module:
+    - field_layout
     - file
+    - layout_discovery
     - path
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.document.default
 targetEntityType: media
 bundle: document
@@ -53,6 +59,11 @@ content:
     weight: 100
     region: content
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5

--- a/web/profiles/sdd/config/install/core.entity_form_display.media.document.media_library.yml
+++ b/web/profiles/sdd/config/install/core.entity_form_display.media.document.media_library.yml
@@ -5,6 +5,13 @@ dependencies:
     - core.entity_form_mode.media.media_library
     - field.field.media.document.field_media_file
     - media.type.document
+  module:
+    - field_layout
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.document.media_library
 targetEntityType: media
 bundle: document

--- a/web/profiles/sdd/config/install/core.entity_form_display.media.image.default.yml
+++ b/web/profiles/sdd/config/install/core.entity_form_display.media.image.default.yml
@@ -6,8 +6,14 @@ dependencies:
     - image.style.thumbnail
     - media.type.image
   module:
+    - field_layout
     - image
+    - layout_discovery
     - path
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.image.default
 targetEntityType: media
 bundle: image
@@ -55,6 +61,11 @@ content:
     weight: 100
     region: content
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5

--- a/web/profiles/sdd/config/install/core.entity_form_display.media.image.media_library.yml
+++ b/web/profiles/sdd/config/install/core.entity_form_display.media.image.media_library.yml
@@ -7,7 +7,13 @@ dependencies:
     - image.style.thumbnail
     - media.type.image
   module:
+    - field_layout
     - image
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.image.media_library
 targetEntityType: media
 bundle: image
@@ -20,6 +26,11 @@ content:
       preview_image_style: thumbnail
     third_party_settings: {  }
     type: image_image
+    region: content
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
     region: content
 hidden:
   created: true

--- a/web/profiles/sdd/config/install/core.entity_form_display.media.local_video.default.yml
+++ b/web/profiles/sdd/config/install/core.entity_form_display.media.local_video.default.yml
@@ -5,8 +5,14 @@ dependencies:
     - field.field.media.local_video.field_media_file
     - media.type.local_video
   module:
+    - field_layout
     - file
+    - layout_discovery
     - path
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.local_video.default
 targetEntityType: media
 bundle: local_video
@@ -53,6 +59,11 @@ content:
     weight: 100
     region: content
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5

--- a/web/profiles/sdd/config/install/core.entity_form_display.media.local_video.media_library.yml
+++ b/web/profiles/sdd/config/install/core.entity_form_display.media.local_video.media_library.yml
@@ -5,11 +5,23 @@ dependencies:
     - core.entity_form_mode.media.media_library
     - field.field.media.local_video.field_media_file
     - media.type.local_video
+  module:
+    - field_layout
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.local_video.media_library
 targetEntityType: media
 bundle: local_video
 mode: media_library
-content: {  }
+content:
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_media_file: true

--- a/web/profiles/sdd/config/install/core.entity_form_display.media.remote_video.default.yml
+++ b/web/profiles/sdd/config/install/core.entity_form_display.media.remote_video.default.yml
@@ -5,8 +5,14 @@ dependencies:
     - field.field.media.remote_video.field_media_oembed_video
     - media.type.remote_video
   module:
+    - field_layout
+    - layout_discovery
     - media
     - path
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.remote_video.default
 targetEntityType: media
 bundle: remote_video
@@ -46,6 +52,11 @@ content:
     weight: 100
     region: content
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5

--- a/web/profiles/sdd/config/install/core.entity_form_display.media.remote_video.media_library.yml
+++ b/web/profiles/sdd/config/install/core.entity_form_display.media.remote_video.media_library.yml
@@ -5,6 +5,13 @@ dependencies:
     - core.entity_form_mode.media.media_library
     - field.field.media.remote_video.field_media_oembed_video
     - media.type.remote_video
+  module:
+    - field_layout
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.remote_video.media_library
 targetEntityType: media
 bundle: remote_video
@@ -16,6 +23,11 @@ content:
       size: 60
       placeholder: ''
     weight: 0
+    third_party_settings: {  }
+    region: content
+  translation:
+    weight: 10
+    settings: {  }
     third_party_settings: {  }
     region: content
 hidden:

--- a/web/profiles/sdd/config/install/core.entity_form_display.node.basic_page.default.yml
+++ b/web/profiles/sdd/config/install/core.entity_form_display.node.basic_page.default.yml
@@ -5,8 +5,14 @@ dependencies:
     - field.field.node.basic_page.body
     - node.type.basic_page
   module:
+    - field_layout
+    - layout_discovery
     - path
     - text
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: node.basic_page.default
 targetEntityType: node
 bundle: basic_page

--- a/web/profiles/sdd/config/install/core.entity_view_display.media.audio.default.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_display.media.audio.default.yml
@@ -6,9 +6,15 @@ dependencies:
     - image.style.thumbnail
     - media.type.audio
   module:
+    - field_layout
     - file
     - image
+    - layout_discovery
     - user
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.audio.default
 targetEntityType: media
 bundle: audio

--- a/web/profiles/sdd/config/install/core.entity_view_display.media.audio.full.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_display.media.audio.full.yml
@@ -6,7 +6,13 @@ dependencies:
     - field.field.media.audio.field_media_file
     - media.type.audio
   module:
+    - field_layout
     - file
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.audio.full
 targetEntityType: media
 bundle: audio

--- a/web/profiles/sdd/config/install/core.entity_view_display.media.audio.media_library.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_display.media.audio.media_library.yml
@@ -7,7 +7,13 @@ dependencies:
     - image.style.medium
     - media.type.audio
   module:
+    - field_layout
     - image
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.audio.media_library
 targetEntityType: media
 bundle: audio

--- a/web/profiles/sdd/config/install/core.entity_view_display.media.document.default.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_display.media.document.default.yml
@@ -6,9 +6,15 @@ dependencies:
     - image.style.thumbnail
     - media.type.document
   module:
+    - field_layout
     - file
     - image
+    - layout_discovery
     - user
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.document.default
 targetEntityType: media
 bundle: document

--- a/web/profiles/sdd/config/install/core.entity_view_display.media.document.full.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_display.media.document.full.yml
@@ -6,7 +6,13 @@ dependencies:
     - field.field.media.document.field_media_file
     - media.type.document
   module:
+    - field_layout
     - file
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.document.full
 targetEntityType: media
 bundle: document

--- a/web/profiles/sdd/config/install/core.entity_view_display.media.document.media_library.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_display.media.document.media_library.yml
@@ -7,7 +7,13 @@ dependencies:
     - image.style.medium
     - media.type.document
   module:
+    - field_layout
     - image
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.document.media_library
 targetEntityType: media
 bundle: document

--- a/web/profiles/sdd/config/install/core.entity_view_display.media.image.default.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_display.media.image.default.yml
@@ -6,8 +6,14 @@ dependencies:
     - image.style.thumbnail
     - media.type.image
   module:
+    - field_layout
     - image
+    - layout_discovery
     - user
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.image.default
 targetEntityType: media
 bundle: image

--- a/web/profiles/sdd/config/install/core.entity_view_display.media.image.full.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_display.media.image.full.yml
@@ -7,7 +7,13 @@ dependencies:
     - image.style.large
     - media.type.image
   module:
+    - field_layout
     - image
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.image.full
 targetEntityType: media
 bundle: image

--- a/web/profiles/sdd/config/install/core.entity_view_display.media.image.media_library.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_display.media.image.media_library.yml
@@ -7,7 +7,13 @@ dependencies:
     - image.style.medium
     - media.type.image
   module:
+    - field_layout
     - image
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.image.media_library
 targetEntityType: media
 bundle: image

--- a/web/profiles/sdd/config/install/core.entity_view_display.media.local_video.default.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_display.media.local_video.default.yml
@@ -6,9 +6,15 @@ dependencies:
     - image.style.thumbnail
     - media.type.local_video
   module:
+    - field_layout
     - file
     - image
+    - layout_discovery
     - user
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.local_video.default
 targetEntityType: media
 bundle: local_video

--- a/web/profiles/sdd/config/install/core.entity_view_display.media.local_video.full.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_display.media.local_video.full.yml
@@ -6,7 +6,13 @@ dependencies:
     - field.field.media.local_video.field_media_file
     - media.type.local_video
   module:
+    - field_layout
     - file
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.local_video.full
 targetEntityType: media
 bundle: local_video

--- a/web/profiles/sdd/config/install/core.entity_view_display.media.local_video.media_library.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_display.media.local_video.media_library.yml
@@ -7,7 +7,13 @@ dependencies:
     - image.style.medium
     - media.type.local_video
   module:
+    - field_layout
     - image
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.local_video.media_library
 targetEntityType: media
 bundle: local_video

--- a/web/profiles/sdd/config/install/core.entity_view_display.media.remote_video.default.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_display.media.remote_video.default.yml
@@ -6,9 +6,15 @@ dependencies:
     - image.style.thumbnail
     - media.type.remote_video
   module:
+    - field_layout
     - image
+    - layout_discovery
     - media
     - user
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.remote_video.default
 targetEntityType: media
 bundle: remote_video

--- a/web/profiles/sdd/config/install/core.entity_view_display.media.remote_video.full.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_display.media.remote_video.full.yml
@@ -6,7 +6,13 @@ dependencies:
     - field.field.media.remote_video.field_media_oembed_video
     - media.type.remote_video
   module:
+    - field_layout
+    - layout_discovery
     - media
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.remote_video.full
 targetEntityType: media
 bundle: remote_video

--- a/web/profiles/sdd/config/install/core.entity_view_display.media.remote_video.media_library.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_display.media.remote_video.media_library.yml
@@ -7,7 +7,13 @@ dependencies:
     - image.style.medium
     - media.type.remote_video
   module:
+    - field_layout
     - image
+    - layout_discovery
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: media.remote_video.media_library
 targetEntityType: media
 bundle: remote_video

--- a/web/profiles/sdd/config/install/core.entity_view_display.node.basic_page.full.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_display.node.basic_page.full.yml
@@ -2,33 +2,40 @@ langcode: en
 status: true
 dependencies:
   config:
+    - core.entity_view_mode.node.full
     - field.field.node.basic_page.body
     - node.type.basic_page
   module:
     - field_layout
     - layout_discovery
+    - manage_display
     - text
-    - user
 third_party_settings:
   field_layout:
     id: layout_onecol
     settings: {  }
-id: node.basic_page.default
+id: node.basic_page.full
 targetEntityType: node
 bundle: basic_page
-mode: default
+mode: full
 content:
   body:
     label: hidden
     type: text_default
-    weight: 101
+    weight: 0
     settings: {  }
     third_party_settings: {  }
     region: content
-  links:
-    weight: 100
+  title:
+    label: hidden
+    type: title
+    weight: -50
     region: content
-    settings: {  }
+    settings:
+      tag: h1
+      linked: false
     third_party_settings: {  }
 hidden:
   langcode: true
+  links: true
+  uid: true

--- a/web/profiles/sdd/config/install/core.entity_view_display.node.basic_page.teaser.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_display.node.basic_page.teaser.yml
@@ -6,8 +6,14 @@ dependencies:
     - field.field.node.basic_page.body
     - node.type.basic_page
   module:
+    - field_layout
+    - layout_discovery
     - text
     - user
+third_party_settings:
+  field_layout:
+    id: layout_onecol
+    settings: {  }
 id: node.basic_page.teaser
 targetEntityType: node
 bundle: basic_page

--- a/web/profiles/sdd/config/install/core.entity_view_mode.node.full.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_mode.node.full.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: false
+dependencies:
+  module:
+    - node
+id: node.full
+label: 'Full content'
+targetEntityType: node
+cache: true

--- a/web/profiles/sdd/config/install/core.entity_view_mode.node.teaser.yml
+++ b/web/profiles/sdd/config/install/core.entity_view_mode.node.teaser.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.teaser
+label: Teaser
+targetEntityType: node
+cache: true

--- a/web/profiles/sdd/config/install/page_manager.page.home.yml
+++ b/web/profiles/sdd/config/install/page_manager.page.home.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies: {  }
+id: home
+label: Home
+description: 'Allow to manage the homepage'
+use_admin_theme: false
+path: /home
+access_logic: and
+access_conditions: {  }
+parameters: {  }

--- a/web/profiles/sdd/config/install/page_manager.page.node_view.yml
+++ b/web/profiles/sdd/config/install/page_manager.page.node_view.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node_view
+label: 'Node view'
+description: 'When enabled, this overrides the default Drupal behavior for displaying nodes at <em>/node/{node}</em>. If you add variants, you may use selection criteria such as node type or language or user access to provide different views of nodes. If no variant is selected, the default Drupal node view will be used. This page only affects nodes viewed as pages, it will not affect nodes viewed in lists or at other locations.'
+use_admin_theme: false
+path: '/node/{node}'
+access_logic: and
+access_conditions: {  }
+parameters:
+  node:
+    machine_name: node
+    type: 'entity:node'
+    label: Node

--- a/web/profiles/sdd/config/install/page_manager.page.site_template.yml
+++ b/web/profiles/sdd/config/install/page_manager.page.site_template.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies: {  }
+id: site_template
+label: 'Site template'
+description: ''
+use_admin_theme: false
+path: /site_template
+access_logic: and
+access_conditions: {  }
+parameters: {  }

--- a/web/profiles/sdd/config/install/page_manager.page_variant.home-panels_variant-0.yml
+++ b/web/profiles/sdd/config/install/page_manager.page_variant.home-panels_variant-0.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - page_manager.page.home
+  module:
+    - panels
+id: home-panels_variant-0
+label: Default
+variant: panels_variant
+variant_settings:
+  blocks: {  }
+  id: panels_variant
+  uuid: 00db4404-a6b0-459f-b0f1-b400f2581a4e
+  label: null
+  weight: 0
+  layout: layout_onecol
+  layout_settings: {  }
+  page_title: Homepage
+  storage_type: page_manager
+  storage_id: home-panels_variant-0
+  builder: standard
+page: home
+weight: 0
+selection_criteria: {  }
+selection_logic: and
+static_context: {  }

--- a/web/profiles/sdd/config/install/page_manager.page_variant.node_view-panels_variant-0.yml
+++ b/web/profiles/sdd/config/install/page_manager.page_variant.node_view-panels_variant-0.yml
@@ -1,0 +1,39 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - page_manager.page.node_view
+  module:
+    - ctools
+    - panels
+id: node_view-panels_variant-0
+label: Default
+variant: panels_variant
+variant_settings:
+  blocks:
+    f6ed6afd-eab3-4cec-8200-0251f4eb14d9:
+      id: 'entity_view:node'
+      label: 'Entity view (Content)'
+      provider: ctools
+      label_display: '0'
+      view_mode: full
+      region: content
+      weight: 0
+      uuid: f6ed6afd-eab3-4cec-8200-0251f4eb14d9
+      context_mapping:
+        entity: node
+  id: panels_variant
+  uuid: 2d053080-a1a2-4400-8c4d-35c2d5177c61
+  label: null
+  weight: 0
+  layout: layout_onecol
+  layout_settings: {  }
+  page_title: ''
+  storage_type: page_manager
+  storage_id: node_view-panels_variant-0
+  builder: standard
+page: node_view
+weight: -9
+selection_criteria: {  }
+selection_logic: and
+static_context: {  }

--- a/web/profiles/sdd/config/install/page_manager.page_variant.node_view-panels_variant-1.yml
+++ b/web/profiles/sdd/config/install/page_manager.page_variant.node_view-panels_variant-1.yml
@@ -1,0 +1,46 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - page_manager.page.node_view
+  module:
+    - ctools
+    - panels
+id: node_view-panels_variant-1
+label: 'Basic page'
+variant: panels_variant
+variant_settings:
+  blocks:
+    1132b35d-1ef6-42bf-a1d6-90b7a4cfc383:
+      id: 'entity_view:node'
+      label: 'Entity view (Content)'
+      provider: ctools
+      label_display: '0'
+      view_mode: full
+      region: content
+      weight: -1
+      uuid: 1132b35d-1ef6-42bf-a1d6-90b7a4cfc383
+      context_mapping:
+        entity: node
+  id: panels_variant
+  uuid: 2e56d596-abfa-4852-8a0a-254f7054cb90
+  label: null
+  weight: 0
+  layout: layout_onecol
+  layout_settings: {  }
+  page_title: ''
+  storage_type: page_manager
+  storage_id: node_view-panels_variant-1
+  builder: standard
+page: node_view
+weight: -10
+selection_criteria:
+  -
+    id: 'entity_bundle:node'
+    bundles:
+      basic_page: basic_page
+    negate: false
+    context_mapping:
+      node: node
+selection_logic: and
+static_context: {  }

--- a/web/profiles/sdd/config/install/page_manager.page_variant.panels_everywhere.yml
+++ b/web/profiles/sdd/config/install/page_manager.page_variant.panels_everywhere.yml
@@ -1,0 +1,96 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - page_manager.page.site_template
+    - system.menu.footer
+    - system.menu.main
+  module:
+    - panels_everywhere
+    - system
+id: panels_everywhere
+label: 'Panels Everywhere'
+variant: panels_everywhere_variant
+variant_settings:
+  blocks:
+    d6542fb7-1a14-4be8-afe2-f852ccf4cb78:
+      id: system_branding_block
+      label: 'Site branding'
+      provider: system
+      label_display: '0'
+      use_site_logo: true
+      use_site_name: false
+      use_site_slogan: false
+      region: first_above
+      weight: 0
+      uuid: d6542fb7-1a14-4be8-afe2-f852ccf4cb78
+      context_mapping: {  }
+    7eb5d802-b9bb-4c90-8e0c-0269a41510d4:
+      id: 'system_menu_block:main'
+      label: 'Main navigation'
+      provider: system
+      label_display: '0'
+      level: 1
+      depth: 0
+      expand_all_items: false
+      region: second_above
+      weight: 0
+      uuid: 7eb5d802-b9bb-4c90-8e0c-0269a41510d4
+      context_mapping: {  }
+    63fea521-f18d-4dd2-bebe-f2c32da78174:
+      id: system_messages_block
+      label: Messages
+      provider: system
+      label_display: '0'
+      region: middle
+      weight: -2
+      uuid: 63fea521-f18d-4dd2-bebe-f2c32da78174
+      context_mapping: {  }
+    3f424cbe-f815-4bce-8540-497347b6a70f:
+      id: local_tasks_block
+      label: Tabs
+      provider: core
+      label_display: '0'
+      primary: true
+      secondary: true
+      region: middle
+      weight: -1
+      uuid: 3f424cbe-f815-4bce-8540-497347b6a70f
+      context_mapping: {  }
+    c32d1a40-cbdd-4d0d-babf-53e59c41ec12:
+      id: system_main_block
+      label: 'Main page content'
+      provider: system
+      label_display: '0'
+      region: middle
+      weight: 0
+      uuid: c32d1a40-cbdd-4d0d-babf-53e59c41ec12
+      context_mapping: {  }
+    d1701e5a-5f16-416d-baac-4bca0ae54697:
+      id: 'system_menu_block:footer'
+      label: Footer
+      provider: system
+      label_display: '0'
+      level: 1
+      depth: 0
+      expand_all_items: false
+      region: first_below
+      weight: -2
+      uuid: d1701e5a-5f16-416d-baac-4bca0ae54697
+      context_mapping: {  }
+  id: panels_everywhere_variant
+  label: null
+  weight: 0
+  layout: layout_twocol_bricks
+  layout_settings: {  }
+  page_title: ''
+  storage_type: page_manager
+  storage_id: panels_everywhere
+  builder: standard
+  route_override_enabled: false
+  uuid: 1f1b2bda-8d73-4229-9fc4-6f51a576fa06
+page: site_template
+weight: 0
+selection_criteria: {  }
+selection_logic: and
+static_context: {  }

--- a/web/profiles/sdd/config/install/system.theme.yml
+++ b/web/profiles/sdd/config/install/system.theme.yml
@@ -1,2 +1,2 @@
 admin: seven
-default: bartik
+default: seven

--- a/web/profiles/sdd/sdd.info.yml
+++ b/web/profiles/sdd/sdd.info.yml
@@ -31,6 +31,7 @@ dependencies:
   - layout_discovery
   - link
   - locale
+  - manage_display
   - media
   - media_library
   - menu_link_content
@@ -38,6 +39,10 @@ dependencies:
   - node
   - options
   - page_cache
+  - page_manager
+  - page_manager_ui
+  - panels
+  - panels_everywhere
   - path
   - quickedit
   - rdf


### PR DESCRIPTION
- Adding panels and site template config and modules to sdd profile : panel_manager, panels_everywhere, manage_dispaly
- Removing behat-fail-aid patch since https://github.com/forceedge01/behat-fail-aid/issues/13 landed in new version
- Removing devel patch since https://www.drupal.org/project/devel/issues/3073850 landed in new version