### PR TITLE
Disable download of translations and only use locale translations files.

### DIFF
--- a/web/profiles/sdd/config/install/locale.settings.yml
+++ b/web/profiles/sdd/config/install/locale.settings.yml
@@ -3,7 +3,7 @@ translate_english: true
 javascript:
   directory: languages
 translation:
-  use_source: remote_and_local
+  use_source: local
   default_filename: '%project-%version.%language.po'
   default_server_pattern: 'https://ftp.drupal.org/files/translations/%core/%project/%project-%version.%language.po'
   overwrite_customized: false

--- a/web/profiles/sdd_core/config/install/locale.settings.yml
+++ b/web/profiles/sdd_core/config/install/locale.settings.yml
@@ -3,7 +3,7 @@ translate_english: true
 javascript:
   directory: languages
 translation:
-  use_source: remote_and_local
+  use_source: local
   default_filename: '%project-%version.%language.po'
   default_server_pattern: 'https://ftp.drupal.org/files/translations/%core/%project/%project-%version.%language.po'
   overwrite_customized: false


### PR DESCRIPTION
Following discussion at https://github.com/skilld-labs/skilld-docker-container/pull/122#issuecomment-525911978 I found we could workaround the download overhead by changing configuration in locale module to only use local translation files and disable download from localize servers