### PR TITLE
Front update - Update artifacts name

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,7 +107,7 @@ prepare:nodejs:
   - yarn install --no-optional --prod
   - yarn run build --verbose
   artifacts:
-    name: "$CI_COMMIT_REF_NAME"
+    name: "$CI_COMMIT_REF_NAME:$CI_COMMIT_SHA"
     paths:
       - ${THEME_PATH}/dist/
   only:


### PR DESCRIPTION
Follow up of https://github.com/skilld-labs/skilld-docker-container/pull/108#discussion_r301143694

# Current result

- Artifacts name is "front-packages"


# Expected result

- Artifacts name should be "$CI_COMMIT_REF_NAME:$CI_COMMIT_SHA"

