### PR TITLE
Update config_inspector to stable release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
   },
   "require-dev": {
     "dmore/behat-chrome-extension": "^1.3",
-    "drupal/config_inspector": "^1.0@beta",
+    "drupal/config_inspector": "^1",
     "drupal/devel": "3.x-dev",
     "drupal/drupal-extension": "^3.4",
     "espend/behat-placeholder-extension": "^1.1",


### PR DESCRIPTION
Currently `make cinsp` assumes we have Drush 9 commands for config_inspector, however those commands were introduced in stable release but we still have beta in composer.json resulting in `make cinsp` failing

This PR is updating the module to stable release to fix the issue