### PR TITLE
CI update: Adding composer cache and refactoring front sniffers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,30 +40,33 @@ sniffers:compose:
   - time composer validate --profile --strict
 
 sniffers:front:
-  cache:
-    key: ${CI_COMMIT_REF_SLUG}-front
-    paths:
-      - ${THEME_PATH}/node_modules/
   stage: sniffers
-  image: node:lts-alpine
   before_script:
   - date
   - pwd
-  - node -v
-  - yarn -v
   script:
-    - cd ${THEME_PATH}
-    - yarn install --no-optional --prod
-    - yarn run lint
+    - make front-install # Dependencies are required for js imports to pass linters
+    - make lintval
   only:
     variables:
       - $THEME_PATH
+  cache:
+    key:
+      files:
+        - ${THEME_PATH}/package.json
+        - ${THEME_PATH}/yarn.lock
+    paths:
+      - ${THEME_PATH}/node_modules/ # Populated during yarn install
+  artifacts:
+    name: "$CI_COMMIT_REF_NAME:$CI_COMMIT_SHA:front"
+    paths:
+      - ${THEME_PATH}/node_modules/ # Populated during yarn install
+  <<: *ra_tags_branches
 
 sniffers:phpcs:
   stage: sniffers
   image: skilldlabs/docker-phpcs-drupal
   script:
-  - ls -lah
   - docker -v
   - make phpcs
   <<: *ra_tags_branches
@@ -71,7 +74,6 @@ sniffers:phpcs:
 sniffers:newlineeof:
   stage: sniffers
   script:
-  - ls -lah
   - make newlineeof
 
 sniffers:hookupdate:
@@ -96,38 +98,63 @@ sniffers:sonarqube:
   - master
   allow_failure: true
 
-prepare:front:
-  cache:
-    key: ${CI_COMMIT_REF_SLUG}-front
-    paths:
-      - ${THEME_PATH}/node_modules/
+
+prepare:back:
   stage: prepare
   script:
-  - make front
-  artifacts:
-    name: "$CI_COMMIT_REF_NAME:$CI_COMMIT_SHA"
+    - docker --version
+    - docker-compose --version
+    - echo "INSTALL_DEV_DEPENDENCIES=TRUE" >> .env.default
+    - make back
+    - docker-compose down # PHP container was required for composer
+  cache:
+    key:
+      files:
+        - composer.json
+        - composer.lock
     paths:
-      - ${THEME_PATH}/dist/
+      - vendor/
+      - web/core/
+      - web/libraries/
+      - web/modules/contrib/
+      - web/profiles/contrib/
+      - web/themes/contrib/
+      - drush/contrib/
+  dependencies: []
+  artifacts:
+    name: "$CI_COMMIT_REF_NAME:$CI_COMMIT_SHA:back"
+    paths:
+      - vendor/
+      - web/
+      - drush/contrib/
+  <<: *ra_tags_branches
+
+prepare:front:
+  stage: prepare
+  script:
+    - make front-build
   only:
     variables:
       - $THEME_PATH
-  <<: *ra_tags_branches
-
-.job_deploy_commit_template: &job_deploy_commit
-  stage: deploy
-  before_script:
-    - date; pwd; ls -lahq;
-    - echo "Clean-up build dir ${BUILD_DIR}"
-    # Always down previous environment.
-    - (if [ -d ${BUILD_DIR} ]; then date; cd ${BUILD_DIR}; pwd; make clean; cd -; rm -rf ${BUILD_DIR}; fi)
-  script:
-    - echo "Removed previous review app ${CI_ENVIRONMENT_URL} from ${BUILD_DIR}."
+  cache:
+    key:
+      files:
+        - ${THEME_PATH}/package.json
+        - ${THEME_PATH}/yarn.lock
+    paths:
+      - ${THEME_PATH}/node_modules/ # Populated during yarn install
   dependencies:
-    - sniffers:phpcs
+    - sniffers:front
+  artifacts:
+    name: "$CI_COMMIT_REF_NAME:$CI_COMMIT_SHA:front"
+    paths:
+      - ${THEME_PATH}/node_modules/ # Populated during yarn install
+      - ${THEME_PATH}/dist/ # Populated during yarn build
   <<: *ra_tags_branches
 
 deploy:review:
-  <<: *job_deploy_commit
+  <<: *ra_tags_branches
+  stage: deploy
   script:
     - echo "Deploy ${CI_ENVIRONMENT_URL} review app to ${BUILD_DIR}."
     - echo "CI_ENVIRONMENT_NAME=${CI_ENVIRONMENT_NAME}"
@@ -144,7 +171,7 @@ deploy:review:
     - echo "INSTALL_DEV_DEPENDENCIES=TRUE" >> .env.default
     - docker --version
     - docker-compose --version
-    - make all MAKE_ENV=ci
+    - make all_ci
   after_script:
     - echo "Started ${CI_ENVIRONMENT_URL} composition in ${BUILD_DIR} from Makefile."
   environment:
@@ -152,12 +179,19 @@ deploy:review:
     name: review/$CI_COMMIT_REF_NAME
     on_stop: stop_review
   dependencies:
+    - prepare:back
     - prepare:front
   when: manual
   allow_failure: false
 
 stop_review:
-  <<: *job_deploy_commit
+  <<: *ra_tags_branches
+  stage: deploy
+  script:
+    - date; pwd; ls -lahq;
+    - echo "Clean-up build dir ${BUILD_DIR}"
+    - (if [ -d ${BUILD_DIR} ]; then date; cd ${BUILD_DIR}; pwd; make clean; cd -; rm -rf ${BUILD_DIR}; fi)
+    - echo "Removed previous review app ${CI_ENVIRONMENT_URL} from ${BUILD_DIR}."
   variables:
     GIT_STRATEGY: none
   when: manual
@@ -175,9 +209,6 @@ test:behat:
   script:
   - echo "Starting job script in ${BUILD_DIR}"
   - cd ${BUILD_DIR}
-  - pwd
-  - ls -lah
-  - ls -lah vendor/bin/
   - make behat
   after_script:
   - cd ${BUILD_DIR}
@@ -203,7 +234,6 @@ test:cinsp:
   script:
   - echo "Starting job script in ${BUILD_DIR}"
   - cd ${BUILD_DIR}
-  - pwd
   - make cinsp
   dependencies:
   - deploy:review
@@ -218,8 +248,6 @@ test:drupalcheck:
   script:
   - echo "Starting job script in ${BUILD_DIR}"
   - cd ${BUILD_DIR}
-  - pwd
-  - ls -lah
   - make drupalcheckval
   dependencies:
   - deploy:review
@@ -234,7 +262,6 @@ test:contentgen:
   script:
   - echo "Starting job script in ${BUILD_DIR}"
   - cd ${BUILD_DIR}
-  - pwd
   - make contentgen
   dependencies:
   - deploy:review
@@ -250,7 +277,6 @@ report:statusreportval:
   script:
   - echo "Starting job script in ${BUILD_DIR}"
   - cd ${BUILD_DIR}
-  - pwd
   - make statusreportval
   dependencies:
   - deploy:review
@@ -265,7 +291,6 @@ report:watchdog:
   script:
   - echo "Starting job script in ${BUILD_DIR}"
   - cd ${BUILD_DIR}
-  - pwd
   - make watchdogval
   dependencies:
   - deploy:review

--- a/scripts/makefile/front.mk
+++ b/scripts/makefile/front.mk
@@ -14,22 +14,40 @@ clear-front:
 	@echo "Clean of node_modules and compiled dist... To skip this action please set CLEAR_FRONT_PACKAGES=no in .env file"
 	$(call frontexec, rm -rf /app/node_modules /app/dist)
 
-front:
+## Install frontend dependencies & build assets
+front: | front-install front-build
+
+front-install:
 	@if [ -d $(shell pwd)/web/themes/custom/$(THEME_NAME) ]; then \
-		echo "Theme directory found. Running front tasks..."; \
+		echo "- Theme directory found. Installing yarn dependencies..."; \
 		docker pull $(IMAGE_FRONT); \
 		$(call frontexec, node -v); \
 		$(call frontexec, yarn -v); \
-		$(call frontexec, yarn install --prod --ignore-optional --check-files); \
+		$(call frontexec, yarn install --ignore-optional --check-files --prod); \
+	else \
+		echo "- Theme directory defined in .env file was not found. Skipping front-install."; \
+	fi
+
+front-build:
+	@if [ -d $(shell pwd)/web/themes/custom/$(THEME_NAME) ]; then \
+		echo "- Theme directory found. Building front assets..."; \
+		docker pull $(IMAGE_FRONT); \
+		$(call frontexec, node -v); \
+		$(call frontexec, yarn -v); \
 		$(call frontexec, yarn build --verbose); \
 	else \
-		echo "Theme directory not found. Skipping front tasks."; \
+		echo "- Theme directory defined in .env file was not found. Skipping front-build."; \
 	fi
+
+lintval:
+	@echo "Running theme linters..."
+	docker pull $(IMAGE_FRONT)
+	$(call frontexec, yarn run lint)
 
 lint:
 	@echo "Running theme linters with fix..."
 	docker pull $(IMAGE_FRONT)
-	$(call frontexec, yarn install --prod --ignore-optional --check-files)
+	$(call frontexec, yarn install --ignore-optional --check-files --prod)
 	$(call frontexec, yarn lint-fix)
 
 storybook:


### PR DESCRIPTION

TLDR :
- **Time required for `prepare` + `deploy` CI steps was reduced from 4 min 56 sec to 2 min 34 sec**


Details : 
- `prepare:back` was added to leverage cache, just like `prepare:front`
   - `deploy:review` new make uses of artefacts from both `prepare:back` and `prepare:back` jobs prepared in previous step
- `make composer` Makefile target was renamed `make back` for homogenization
- `sniffers:front` CI job was reworked to not run directly in node image
   - to benefit from proper gitlab-ci caching (as container based cache volumes creation is disabled by default)
   - to fix [artifacts ownership](https://gitlab.com/gitlab-org/gitlab-runner/issues/1180) issue from one job to another
- Arbitrary string cache keys were replaced by file based (SHA checksum tags) cache keys
   - to create more meaningful cache invalidation and share cached dependencies between all branch of projects AMAP
- `make front` was splitted into `make front-install` and `make front-build` in order to execute only `make front-build` in prepare:front CI step and save additional resources
- `job_deploy_commit` anchor template was removed from `deploy:review` since
   - RA lifecycle is managed by bot in our case and doesn't seem necessary according to tests
   - it's useful content was moved to `stop_review`
- `artifacts` archived were named differently for back and front dependencies using predefined gitlab variables
- Faulty `make all MAKE_ENV=ci` command was removed to be fixed in another PR
- Missing _.PHONY_ commands were added (mostly from front.mk)
- `pwd` and `ls -lah` debug commands were cleaned for style

