### PR TITLE
Cleaning CI prepare:front artefacts and cache

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,19 +136,11 @@ prepare:front:
   only:
     variables:
       - $THEME_PATH
-  cache:
-    key:
-      files:
-        - ${THEME_PATH}/package.json
-        - ${THEME_PATH}/yarn.lock
-    paths:
-      - ${THEME_PATH}/node_modules/ # Populated during yarn install
   dependencies:
     - sniffers:front
   artifacts:
     name: "$CI_COMMIT_REF_NAME:$CI_COMMIT_SHA:front"
     paths:
-      - ${THEME_PATH}/node_modules/ # Populated during yarn install
       - ${THEME_PATH}/dist/ # Populated during yarn build
   <<: *ra_tags_branches
 


### PR DESCRIPTION
Follow up of https://github.com/skilld-labs/skilld-docker-container/pull/191/files#r357864504 to clean prepare:front from not useful node_modules caching and artifacts uploading