### PR TITLE
Removing unuse imports and adding proper message for select choice

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -1,13 +1,7 @@
 <?php
 
 use Drupal\DrupalExtension\Context\RawDrupalContext;
-use Drupal\Core\Url;
-use Drupal\node\Entity\Node;
 use Behat\Behat\Context\SnippetAcceptingContext;
-use Behat\Behat\Tester\Exception\PendingException;
-use Behat\Gherkin\Node\PyStringNode;
-use Behat\Gherkin\Node\TableNode;
-use Behat\Mink\Driver\Selenium2Driver;
 
 
 /**
@@ -244,6 +238,9 @@ JS;
   public function iSelectOptionNumberInChoices($selector, $number) {
     $page = $this->getSession()->getPage();
     $element = $page->find('css', $selector);
+    if (!$element) {
+      throw new \Exception(sprintf('Element "%s" not found', $selector));
+    }
     $trigger = $element->getParent();
     $trigger->click();
     $items = $trigger->getParent()->findAll('css', '.choices__list--dropdown > .choices__list > .choices__item');


### PR DESCRIPTION
When select element isn't found in page we get fatal error with message:
`Fatal error: Call to a member function getParent() on null`
so it would be better to add a more user-friendly message which adds information about the element not found
