### PR TITLE
Workaround for outdated git in CentOS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@
 variables:
   GIT_DEPTH: "3"
   THEME_PATH: "" # Update to enable front jobs
+  GIT_STRATEGY: clone # Workaround until git is updated in runner, see https://gitlab.com/gitlab-org/gitlab-foss/issues/60466
 
 image: skilldlabs/php:73
 


### PR DESCRIPTION
As stated in https://gitlab.com/gitlab-org/gitlab-foss/issues/60466#note_160499111 we often get `git fetch` errors because of outdated git binaries included in CentOS.

This MR includes workaround suggested at https://gitlab.com/gitlab-org/gitlab-foss/issues/60466#note_202961108 until we get to update git on runners