### PR TITLE
Revert "Adding Drupal console back"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
     "drupal/components": "^1",
     "drupal/config_installer": "^1",
     "drupal/core-recommended": "^8.8.0",
-    "drupal/console": "^1",
     "drupal/default_content": "^1",
     "drupal/file_entity": "^2",
     "drupal/focal_point": "^1.2",


### PR DESCRIPTION
Reverts skilld-labs/skilld-docker-container#215

- Console has a lot of collisions with current core dependencies
- It is badly maintained and derails main core progress on https://www.drupal.org/project/drupal/issues/2242947
- It supposed to be only developer tool so if something needs it it must be in `require-dev`