### PR TITLE
Fix "class not found" errors in behat

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -2,7 +2,8 @@
 
 use Drupal\DrupalExtension\Context\RawDrupalContext;
 use Behat\Behat\Context\SnippetAcceptingContext;
-
+use Behat\Mink\Exception\ExpectationException;
+use Behat\Mink\Exception\ResponseTextException;
 
 /**
  * Defines application features from the specific context.


### PR DESCRIPTION
This PR adds missing imports in FeatureContext.php which trigger "class not found" errors.