### PR TITLE
Adding rerun for failed behat scenarios

### DIFF
--- a/scripts/makefile/tests.mk
+++ b/scripts/makefile/tests.mk
@@ -119,7 +119,7 @@ endif
 	@echo "Running Behat scenarios against http://$(BASE_URL)"
 	$(call php, composer install -o)
 	$(call php, vendor/bin/behat -V)
-	$(call php, vendor/bin/behat --colors)
+	$(call php, vendor/bin/behat --colors) || $(call php, vendor/bin/behat --colors --rerun)
 	make browser_driver_stop
 
 ## List existing behat definitions


### PR DESCRIPTION
We could rerun behat failed tests inmediately after the 1st test to discard timeout errors.