### PR TITLE
Only allow translation import from local files

### DIFF
--- a/web/profiles/sdd/config/install/locale.settings.yml
+++ b/web/profiles/sdd/config/install/locale.settings.yml
@@ -3,7 +3,7 @@ translate_english: true
 javascript:
   directory: languages
 translation:
-  use_source: remote_and_local
+  use_source: local
   default_filename: '%project-%version.%language.po'
   default_server_pattern: 'https://ftp.drupal.org/files/translations/%core/%project/%project-%version.%language.po'
   overwrite_customized: false


### PR DESCRIPTION
To prevent constantly downloading external translation files during project build we should better restrict locale to only import local files