### PR TITLE
Updating docker labels to support Traefik v2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ image: skilldlabs/php:73
 # Tags defines which runner to use (expected shell runner)
 .ra_tags: &ra_tags
   tags:
-    - review-apps-4
+    - XXX # Mandatory, should equal to tag of available runner server with docker + docker-compose + traefik
 
 .ra_only: &ra_only
   only:
@@ -36,7 +36,6 @@ stages:
   - tests
   - reports
   - document
-
 
 sniffers:clang:
   stage: sniffers

--- a/docker/docker-compose.override.yml.default
+++ b/docker/docker-compose.override.yml.default
@@ -45,13 +45,16 @@ services:
       - front
     labels:
       - 'traefik.enable=true'
+      # Treafik 1.x
       - 'traefik.backend=${MAIN_DOMAIN_NAME}_mail'
-      - 'traefik.port=8025'
       - 'traefik.frontend.rule=Host:mail-${MAIN_DOMAIN_NAME}'
       - 'traefik.frontend.redirect.entryPoint=https'
-      - 'traefik.http.services.mailhog-${COMPOSE_PROJECT_NAME}.loadbalancer.server.port=8025'
-      - 'traefik.http.routers.mailhog-${COMPOSE_PROJECT_NAME}.tls=true'
+      - 'traefik.port=8025'
+      # Treafik 2.x
+      - 'traefik.http.routers.mailhog-${COMPOSE_PROJECT_NAME}.rule=Host(`mail-${MAIN_DOMAIN_NAME}`)'
       - 'traefik.http.routers.mailhog-${COMPOSE_PROJECT_NAME}.tls.certresolver=dns'
+      - 'traefik.http.routers.mailhog-${COMPOSE_PROJECT_NAME}.tls=true'
+      - 'traefik.http.services.mailhog-${COMPOSE_PROJECT_NAME}.loadbalancer.server.port=8025'
 
   nginx:
 # Uncomment for MacOS.
@@ -62,20 +65,29 @@ services:
 #     - ./nginx/ssl:/etc/nginx/ssl:Z
     labels:
       - 'traefik.enable=true'
+      # Treafik 1.x
       - 'traefik.backend=${MAIN_DOMAIN_NAME}_web'
-      - 'traefik.port=80'
       - 'traefik.frontend.rule=Host:${MAIN_DOMAIN_NAME}'
       - 'traefik.frontend.redirect.entryPoint=https'
-      - 'traefik.http.routers.nginx-${COMPOSE_PROJECT_NAME}.tls=true'
+      - 'traefik.port=80'
+      # Treafik 2.x
+      - 'traefik.http.routers.nginx-${COMPOSE_PROJECT_NAME}.rule=Host(`${MAIN_DOMAIN_NAME}`)'
       - 'traefik.http.routers.nginx-${COMPOSE_PROJECT_NAME}.tls.certresolver=dns'
+      - 'traefik.http.routers.nginx-${COMPOSE_PROJECT_NAME}.tls=true'
 
 #  solr:
 #    labels:
 #      - 'traefik.enable=true'
+#      # Treafik 1.x
 #      - 'traefik.backend=${MAIN_DOMAIN_NAME}_solr'
-#      - 'traefik.port=8983'
 #      - 'traefik.frontend.rule=Host:solr-${MAIN_DOMAIN_NAME}'
 #      - 'traefik.frontend.redirect.entryPoint=https'
+#      - 'traefik.port=8983'
+#      # Treafik 2.x
+#      - 'traefik.http.routers.solr-${COMPOSE_PROJECT_NAME}.rule=Host(`solr-${MAIN_DOMAIN_NAME}`)'
+#      - 'traefik.http.routers.solr-${COMPOSE_PROJECT_NAME}.tls.certresolver=dns'
+#      - 'traefik.http.routers.solr-${COMPOSE_PROJECT_NAME}.tls=true'
+#      - 'traefik.http.services.solr-${COMPOSE_PROJECT_NAME}.loadbalancer.server.port=8983'
 
 #networks:
 #  front:


### PR DESCRIPTION
Follow up of https://github.com/skilld-labs/skilld-docker-container/pull/230