### PR TITLE
Drupal 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,11 @@ vendor
 web/*.*
 web/core/
 web/libraries/
+web/modules/*.*
 web/modules/contrib/
+web/themes/*.*
 web/themes/contrib/
+web/profiles/*.*
 web/profiles/contrib/config_installer/
 web/sites/
 

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,6 @@ else
 	@echo "Installing composer dependencies, without dev ones"
 	$(call php, composer install --prefer-dist -o --no-dev)
 endif
-	$(call php, composer drupal-scaffold)
 	$(call php, composer create-required-files)
 
 TESTER_NAME = tester

--- a/composer.json
+++ b/composer.json
@@ -16,38 +16,40 @@
     }
   ],
   "require": {
-    "composer/installers": "^1.2",
+    "composer/installers": "^1.9",
     "cweagans/composer-patches": "^1.6.5",
-    "drupal-composer/drupal-scaffold": "^2.6",
     "drupal/better_normalizers": "^1.0@beta",
-    "drupal/block_content_permissions": "^1.8",
-    "drupal/core-recommended": "^8.9",
-    "drupal/core-vendor-hardening": "^8.9",
+    "drupal/block_content_permissions": "1.x-dev",
+    "drupal/core-composer-scaffold": "^9.0",
+    "drupal/core-project-message": "^9.0",
+    "drupal/core-recommended": "^9",
+    "drupal/core-vendor-hardening": "^9.0",
     "drupal/default_content": "^1",
-    "drupal/file_entity": "^2",
-    "drupal/focal_point": "^1.2",
+    "drupal/file_entity": "2.x-dev",
+    "drupal/focal_point": "^1.4",
     "drupal/google_tag": "^1.2",
-    "drupal/honeypot": "^1.30",
+    "drupal/honeypot": "^2",
     "drupal/layout_builder_modal": "^1.1",
     "drupal/layout_builder_restrictions": "^2.7",
     "drupal/layout_library": "^1.0@beta",
-    "drupal/lb_ux": "^1.0@beta",
+    "drupal/lb_ux": "1.x-dev",
     "drupal/manage_display": "^1.0@alpha",
-    "drupal/menu_admin_per_menu": "^1.0",
-    "drupal/menu_link_attributes": "^1.0",
-    "drupal/page_manager": "4.x-dev",
-    "drupal/panels_everywhere": "^4.0@beta",
-    "drupal/paragraphs": "^1.9",
-    "drupal/pathauto": "^1.6",
-    "drupal/rabbit_hole": "^1.0@beta",
-    "drupal/redirect": "^1.4",
-    "drupal/svg_image": "^1.10",
-    "drupal/swiftmailer": "^1",
-    "drupal/telephone_validation": "^2.2",
+    "drupal/menu_admin_per_menu": "^1.1",
+    "drupal/menu_link_attributes": "1.x-dev",
+    "drupal/page_manager": "^4.0.0-beta6",
+    "drupal/panels": "^4.6",
+    "drupal/panels_everywhere": "4.x-dev",
+    "drupal/paragraphs": "^1.11",
+    "drupal/pathauto": "^1.8",
+    "drupal/rabbit_hole": "^1.0.0-beta7",
+    "drupal/redirect": "^1.6",
+    "drupal/svg_image": "^1.14",
+    "drupal/swiftmailer": "^2",
+    "drupal/telephone_validation": "^2.3",
     "drupal/token": "^1",
-    "drupal/username_enumeration_prevention": "^1.0",
-    "drupal/views_bulk_edit": "^2.3",
-    "drupal/webform": "^5.4",
+    "drupal/username_enumeration_prevention": "^1.1",
+    "drupal/views_bulk_edit": "2.x-dev",
+    "drupal/webform": "^6",
     "drush/drush": "^10.1.0",
     "skilldlabs/drupal-cleanup": "^1",
     "zaporylie/composer-drupal-optimizations": "^1.0"
@@ -56,7 +58,7 @@
     "dmore/behat-chrome-extension": "^1.3",
     "drupal/config_inspector": "^1",
     "drupal/devel": "3.x-dev",
-    "drupal/drupal-extension": "^3.4",
+    "drupal/drupal-extension": "^4",
     "drupal/upgrade_status": "^2.6",
     "espend/behat-placeholder-extension": "^1.1",
     "genesis/behat-fail-aid": "^2.1",
@@ -68,7 +70,12 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "preferred-install": {
+      "drupal/lb_ux": "source",
+      "drupal/panels_everywhere": "source",
+      "*": "dist"
+    }
   },
   "autoload": {
     "classmap": [
@@ -76,7 +83,6 @@
     ]
   },
   "scripts": {
-    "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
     "create-required-files": "SkilldDrupal\\composer\\ScriptHandler::createRequiredFiles",
     "list-scaffold-files": [
       "SkilldDrupal\\composer\\ScriptHandler::listScaffoldFiles"
@@ -95,7 +101,7 @@
       "web/modules/contrib/{$name}": ["type:drupal-module"],
       "web/profiles/contrib/{$name}": ["type:drupal-profile"],
       "web/themes/contrib/{$name}": ["type:drupal-theme"],
-      "drush/contrib/{$name}": ["type:drupal-drush"]
+      "drush/Commands/contrib/{$name}": ["type:drupal-drush"]
     },
     "drupal-scaffold": {
       "locations": {
@@ -124,7 +130,7 @@
     },
     "patches": {
       "drupal/core": {
-        "Setting required on radios marks all options required": "https://www.drupal.org/files/issues/2019-07-30/2731991-42.patch",
+        "Setting required on radios marks all options required": "https://www.drupal.org/files/issues/2020-05-26/2731991-50.patch",
         "Translated field denormalization creates duplicate values": "https://www.drupal.org/files/issues/2019-07-02/2904423-core_8_8-72.patch",
         "Fix multilingual site's layout edit context issue": "https://www.drupal.org/files/issues/2019-12-19/3101231-19.patch",
         "SQLite database locking errors cause fatal errors": "https://www.drupal.org/files/issues/1120020-59.patch",
@@ -140,21 +146,28 @@
       "drush/drush": {
         "Import multiple custom translation po files": "https://patch-diff.githubusercontent.com/raw/drush-ops/drush/pull/4251.patch"
       },
-      "drupal/lb_ux": {
-        "Cog icon not showing when Preview disabled": "https://www.drupal.org/files/issues/2020-05-22/3116402-8.patch",
-        "Errors when using with modules that alter a section's contextual menu": "https://www.drupal.org/files/issues/2020-05-22/3106939-4.patch"
+      "drupal/block_content_permissions": {
+        "Allow accessing the Custom block library page without Administer blocks permission": "https://www.drupal.org/files/issues/2020-06-05/block_content_permissions-access_listing_page-2920739-31.patch"
       },
       "drupal/default_content": {
         "Do not reimport existing entities": "https://www.drupal.org/files/issues/do_not_reimport-2698425-56.patch"
       },
-      "drupal/block_content_permissions": {
-        "Allow accessing the Custom block library page without Administer blocks permission": "https://www.drupal.org/files/issues/2019-06-20/block_content_permissions-access_listing_page-2920739-23.patch"
+      "drupal/focal_point": {
+        "Integrate focal point with media_library": "https://www.drupal.org/files/issues/2019-12-11/focal_point-compatibility-with-media-libary-3094478-2.patch"
+      },
+      "drupal/lb_ux": {
+        "Cog icon not showing when Preview disabled": "https://www.drupal.org/files/issues/2020-05-22/3116402-8.patch",
+        "Errors when using with modules that alter a section's contextual menu": "https://www.drupal.org/files/issues/2020-05-22/3106939-4.patch",
+        "Indicate Drupal 8/9 compatibility via core_version_requirement": "https://www.drupal.org/files/issues/2020-05-22/d9_compatibility-3138698-4.patch"
+      },
+      "drupal/manage_display": {
+        "Drupal 9 compatibility": "https://www.drupal.org/files/issues/2020-04-01/manage_display.d9.3124061-2.patch"
       },
       "drupal/menu_link_attributes": {
         "Add missing schema for menu_link_attributes": "https://patch-diff.githubusercontent.com/raw/yannickoo/menu_link_attributes/pull/52.patch"
       },
-      "drupal/focal_point": {
-        "Integrate focal point with media_library": "https://www.drupal.org/files/issues/2019-12-11/focal_point-compatibility-with-media-libary-3094478-2.patch"
+      "drupal/panels_everywhere": {
+        "Drupal 9 compatibility fixes for Panels Everywhere": "https://www.drupal.org/files/issues/2020-05-14/d9-compatibility-3111407-7.patch"
       }
     }
   }

--- a/scripts/makefile/tests.mk
+++ b/scripts/makefile/tests.mk
@@ -59,7 +59,7 @@ endif
 ## Validate composer.json file
 compval:
 	@echo "Composer.json validation..."
-	# Add --strict back when page_manager includes https://www.drupal.org/project/page_manager/issues/2960739 in next release.
+	# Can't use --strict cause we need dev versions for d9 compatibility
 	@docker run --rm -v `pwd`:`pwd` -w `pwd` $(IMAGE_PHP) composer validate
 
 ## Validate hook_update_N()

--- a/web/modules/custom/project_default_content/project_default_content.info.yml
+++ b/web/modules/custom/project_default_content/project_default_content.info.yml
@@ -3,7 +3,7 @@ description: Creates default content fixtures for the project. This module comes
 package: Custom
 
 type: module
-core: 8.x
+core_version_requirement: ^8.7.7 || ^9
 
 dependencies:
   - default_content:default_content


### PR DESCRIPTION
Update drupal core to v9 including all required dependencies.

We need to consider the issues previously reported in https://github.com/skilld-labs/skilld-docker-container/pull/233 here as well