### PR TITLE
Replace drupal-check by Upgrade Status + Drupal Rector

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -314,6 +314,21 @@ test:drupalrector:
   <<: *ra_tags
   <<: *ra_only
 
+test:upgradestatus:
+  stage: tests
+  environment:
+    url: https://${CI_ENVIRONMENT_SLUG}-${CI_PROJECT_PATH_SLUG}.${REVIEW_DOMAIN}
+    name: review/$CI_COMMIT_REF_NAME
+    on_stop: stop_review
+  script:
+  - echo "Starting job script in ${BUILD_DIR}"
+  - cd ${BUILD_DIR}
+  - make upgradestatusval
+  dependencies:
+  - deploy:review
+  <<: *ra_tags
+  <<: *ra_only
+
 test:contentgen:
   stage: tests
   environment:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -299,6 +299,21 @@ test:drupalcheck:
   <<: *ra_tags
   <<: *ra_only
 
+test:drupalrector:
+  stage: tests
+  environment:
+    url: https://${CI_ENVIRONMENT_SLUG}-${CI_PROJECT_PATH_SLUG}.${REVIEW_DOMAIN}
+    name: review/$CI_COMMIT_REF_NAME
+    on_stop: stop_review
+  script:
+  - echo "Starting job script in ${BUILD_DIR}"
+  - cd ${BUILD_DIR}
+  - make drupalrectorval
+  dependencies:
+  - deploy:review
+  <<: *ra_tags
+  <<: *ra_only
+
 test:contentgen:
   stage: tests
   environment:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -284,21 +284,6 @@ test:cinsp:
   <<: *ra_tags
   <<: *ra_only
 
-test:drupalcheck:
-  stage: tests
-  environment:
-    url: https://${CI_ENVIRONMENT_SLUG}-${CI_PROJECT_PATH_SLUG}.${REVIEW_DOMAIN}
-    name: review/$CI_COMMIT_REF_NAME
-    on_stop: stop_review
-  script:
-  - echo "Starting job script in ${BUILD_DIR}"
-  - cd ${BUILD_DIR}
-  - make drupalcheckval
-  dependencies:
-  - deploy:review
-  <<: *ra_tags
-  <<: *ra_only
-
 test:drupalrector:
   stage: tests
   environment:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Add utility functions and scripts to the container
 include scripts/makefile/*.mk
 
-.PHONY: all fast allfast provision si exec exec0 down clean dev drush info phpcs phpcbf hooksymlink clang cinsp compval watchdogval drupalcheckval behat sniffers tests front front-install front-build clear-front lintval lint storybook back behatdl behatdi browser_driver browser_driver_stop statusreportval contentgen newlineeof localize
+.PHONY: all fast allfast provision si exec exec0 down clean dev drush info phpcs phpcbf hooksymlink clang cinsp compval watchdogval drupalcheckval drupalrectorval behat sniffers tests front front-install front-build clear-front lintval lint storybook back behatdl behatdi browser_driver browser_driver_stop statusreportval contentgen newlineeof localize
 .DEFAULT_GOAL := help
 
 # https://stackoverflow.com/a/6273809/1826109

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Add utility functions and scripts to the container
 include scripts/makefile/*.mk
 
-.PHONY: all fast allfast provision si exec exec0 down clean dev drush info phpcs phpcbf hooksymlink clang cinsp compval watchdogval drupalcheckval drupalrectorval upgradestatusval behat sniffers tests front front-install front-build clear-front lintval lint storybook back behatdl behatdi browser_driver browser_driver_stop statusreportval contentgen newlineeof localize
+.PHONY: all fast allfast provision si exec exec0 down clean dev drush info phpcs phpcbf hooksymlink clang cinsp compval watchdogval drupalrectorval upgradestatusval behat sniffers tests front front-install front-build clear-front lintval lint storybook back behatdl behatdi browser_driver browser_driver_stop statusreportval contentgen newlineeof localize
 .DEFAULT_GOAL := help
 
 # https://stackoverflow.com/a/6273809/1826109

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Add utility functions and scripts to the container
 include scripts/makefile/*.mk
 
-.PHONY: all fast allfast provision si exec exec0 down clean dev drush info phpcs phpcbf hooksymlink clang cinsp compval watchdogval drupalcheckval drupalrectorval behat sniffers tests front front-install front-build clear-front lintval lint storybook back behatdl behatdi browser_driver browser_driver_stop statusreportval contentgen newlineeof localize
+.PHONY: all fast allfast provision si exec exec0 down clean dev drush info phpcs phpcbf hooksymlink clang cinsp compval watchdogval drupalcheckval drupalrectorval upgradestatusval behat sniffers tests front front-install front-build clear-front lintval lint storybook back behatdl behatdi browser_driver browser_driver_stop statusreportval contentgen newlineeof localize
 .DEFAULT_GOAL := help
 
 # https://stackoverflow.com/a/6273809/1826109

--- a/composer.json
+++ b/composer.json
@@ -55,9 +55,11 @@
     "drupal/config_inspector": "^1",
     "drupal/devel": "3.x-dev",
     "drupal/drupal-extension": "^3.4",
+    "drupal/upgrade_status": "^2.6",
     "espend/behat-placeholder-extension": "^1.1",
     "genesis/behat-fail-aid": "^2.1",
     "mglaman/drupal-check": "^1.1",
+    "palantirnet/drupal-rector": "^0.5.4",
     "phpspec/prophecy": "^1.7",
     "phpunit/phpunit": "^6.5 || ^7",
     "symfony/phpunit-bridge": "^3.4.3"

--- a/composer.json
+++ b/composer.json
@@ -58,10 +58,7 @@
     "drupal/upgrade_status": "^2.6",
     "espend/behat-placeholder-extension": "^1.1",
     "genesis/behat-fail-aid": "^2.1",
-    "palantirnet/drupal-rector": "^0.5.4",
-    "phpspec/prophecy": "^1.7",
-    "phpunit/phpunit": "^6.5 || ^7",
-    "symfony/phpunit-bridge": "^3.4.3"
+    "palantirnet/drupal-rector": "^0.5.4"
   },
   "conflict": {
     "drupal/drupal": "*"

--- a/composer.json
+++ b/composer.json
@@ -104,6 +104,9 @@
       }
     },
     "composer-exit-on-patch-failure": true,
+    "patchLevel": {
+      "drupal/core": "-p2"
+    },
     "patches": {
       "drupal/core": {
         "Setting required on radios marks all options required": "https://www.drupal.org/files/issues/2019-07-30/2731991-42.patch",

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,6 @@
     "drupal/upgrade_status": "^2.6",
     "espend/behat-placeholder-extension": "^1.1",
     "genesis/behat-fail-aid": "^2.1",
-    "mglaman/drupal-check": "^1.1",
     "palantirnet/drupal-rector": "^0.5.4",
     "phpspec/prophecy": "^1.7",
     "phpunit/phpunit": "^6.5 || ^7",

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,10 @@
     "drupal/drupal-extension": "^3.4",
     "espend/behat-placeholder-extension": "^1.1",
     "genesis/behat-fail-aid": "^2.1",
-    "mglaman/drupal-check": "^1.1"
+    "mglaman/drupal-check": "^1.1",
+    "phpspec/prophecy": "^1.7",
+    "phpunit/phpunit": "^6.5 || ^7",
+    "symfony/phpunit-bridge": "^3.4.3"
   },
   "conflict": {
     "drupal/drupal": "*"

--- a/rector.yml
+++ b/rector.yml
@@ -13,6 +13,7 @@ parameters:
     - 'web/core/modules'
     - 'web/modules'
     - 'web/profiles'
+    - 'web/themes'
 
   exclude_paths:
   # If you would like to skip test directories, uncomment the following lines:

--- a/rector.yml
+++ b/rector.yml
@@ -1,0 +1,38 @@
+imports:
+  - { resource: "vendor/palantirnet/drupal-rector/config/drupal-8/drupal-8-all-deprecations.yml" }
+  # includes:
+  # - { resource: "vendor/palantirnet/drupal-rector/config/drupal-8/drupal-8.0-deprecations.yml" }
+  # - { resource: "vendor/palantirnet/drupal-rector/config/drupal-8/drupal-8.4-deprecations.yml" }
+  # - { resource: "vendor/palantirnet/drupal-rector/config/drupal-8/drupal-8.5-deprecations.yml" }
+  # - { resource: "vendor/palantirnet/drupal-rector/config/drupal-8/drupal-8.6-deprecations.yml" }
+  # - { resource: "vendor/palantirnet/drupal-rector/config/drupal-8/drupal-8.7-deprecations.yml" }
+
+parameters:
+  autoload_paths:
+    - 'web/core'
+    - 'web/core/modules'
+    - 'web/modules'
+    - 'web/profiles'
+
+  exclude_paths:
+  # If you would like to skip test directories, uncomment the following lines:
+  # Upgrade status contains intentionally invalid code for their own tests.
+    - 'web/modules/contrib/upgrade_status'
+  #   - '*/Tests/*'
+
+  file_extensions:
+    - module
+    - theme
+    - install
+    - profile
+    - inc
+    - engine
+
+  # Create `use` statements.
+  auto_import_names: true
+  # Do not convert `\Drupal` to `Drupal`, etc.
+  import_short_classes: false
+  # This will not import classes used in PHP DocBlocks, like in /** @var \Some\Class */
+  import_doc_blocks: false
+
+services: ~

--- a/scripts/makefile/config-inspector-validation.sh
+++ b/scripts/makefile/config-inspector-validation.sh
@@ -12,6 +12,7 @@ if [ "$ERROR_COUNT" -gt "0" ]; then
 	echo -e "\nConfiguration is not valid : \n- Go to \033[1m/admin/config/development/configuration/inspect\033[0m for more details\n"
 	exit 1
 else
+	drush pmu config_inspector -y
 	echo -e "Configuration is valid"
 	exit 0
 fi

--- a/scripts/makefile/tests.mk
+++ b/scripts/makefile/tests.mk
@@ -165,5 +165,5 @@ endif
 sniffers: | clang compval phpcs newlineeof
 
 ## Run all tests & validations (including sniffers)
-tests: | sniffers cinsp drupalcheckval behat watchdogval statusreportval
+tests: | sniffers cinsp drupalrectorval upgradestatusval behat watchdogval statusreportval
 

--- a/scripts/makefile/tests.mk
+++ b/scripts/makefile/tests.mk
@@ -95,10 +95,14 @@ drupalrectorval:
 
 ## Validate upgrade-status
 upgradestatusval:
+ifneq ("$(wildcard rector.yml)","")
 	@echo "Drupal-check validation..."
 	$(call php, composer install -o)
 	$(call php, drush en -y upgrade_status)
 	$(call php, drush us-a --all --ignore-contrib --ignore-uninstalled)
+else
+	@echo "rector.yml file does not exist"
+endif
 
 ## Validate newline at the end of files
 newlineeof:

--- a/scripts/makefile/tests.mk
+++ b/scripts/makefile/tests.mk
@@ -100,6 +100,13 @@ drupalrectorval:
 	$(call php, vendor/bin/rector -V)
 	$(call php, vendor/bin/rector process --dry-run --no-progress-bar web/modules/custom web/themes/custom)
 
+## Validate upgrade-status
+upgradestatusval:
+	@echo "Drupal-check validation..."
+	$(call php, composer install -o)
+	$(call php, drush en -y upgrade_status)
+	$(call php, drush us-a --all --ignore-contrib --ignore-uninstalled)
+
 ## Validate newline at the end of files
 newlineeof:
 ifneq ("$(wildcard scripts/makefile/newlineeof.sh)","")

--- a/scripts/makefile/tests.mk
+++ b/scripts/makefile/tests.mk
@@ -88,19 +88,19 @@ endif
 
 ## Validate drupal-rector
 drupalrectorval:
+ifneq ("$(wildcard rector.yml)","")
 	@echo "Drupal Rector validation..."
 	$(call php, composer install -o)
 	$(call php, vendor/bin/rector -V)
 	$(call php, vendor/bin/rector process --dry-run --no-progress-bar web/modules/custom web/themes/custom)
-
-## Validate upgrade-status
-upgradestatusval:
-ifneq ("$(wildcard rector.yml)","")
-	@echo "Upgrade status validation..."
-	@$(call php, /bin/sh ./scripts/makefile/upgrade-status-validation.sh)
 else
 	@echo "rector.yml file does not exist"
 endif
+
+## Validate upgrade-status
+upgradestatusval:
+	@echo "Upgrade status validation..."
+	@$(call php, /bin/sh ./scripts/makefile/upgrade-status-validation.sh)
 
 ## Validate newline at the end of files
 newlineeof:

--- a/scripts/makefile/tests.mk
+++ b/scripts/makefile/tests.mk
@@ -88,7 +88,7 @@ endif
 
 ## Validate drupal-rector
 drupalrectorval:
-	@echo "Drupal-check validation..."
+	@echo "Drupal Rector validation..."
 	$(call php, composer install -o)
 	$(call php, vendor/bin/rector -V)
 	$(call php, vendor/bin/rector process --dry-run --no-progress-bar web/modules/custom web/themes/custom)
@@ -96,10 +96,8 @@ drupalrectorval:
 ## Validate upgrade-status
 upgradestatusval:
 ifneq ("$(wildcard rector.yml)","")
-	@echo "Drupal-check validation..."
-	$(call php, composer install -o)
-	$(call php, drush en -y upgrade_status)
-	$(call php, drush us-a --all --ignore-contrib --ignore-uninstalled)
+	@echo "Upgrade status validation..."
+	@$(call php, /bin/sh ./scripts/makefile/upgrade-status-validation.sh)
 else
 	@echo "rector.yml file does not exist"
 endif

--- a/scripts/makefile/tests.mk
+++ b/scripts/makefile/tests.mk
@@ -86,13 +86,6 @@ else
 	@echo "scripts/makefile/status-report-validation.sh file does not exist"
 endif
 
-## Validate drupal-check
-drupalcheckval:
-	@echo "Drupal-check validation..."
-	$(call php, composer install -o)
-	$(call php, vendor/bin/drupal-check -V)
-	$(call php, vendor/bin/drupal-check -ad -vv -n --no-progress web/modules/custom/)
-
 ## Validate drupal-rector
 drupalrectorval:
 	@echo "Drupal-check validation..."

--- a/scripts/makefile/tests.mk
+++ b/scripts/makefile/tests.mk
@@ -99,8 +99,13 @@ endif
 
 ## Validate upgrade-status
 upgradestatusval:
+ifneq ("$(wildcard scripts/makefile/upgrade-status-validation.sh)","")
 	@echo "Upgrade status validation..."
+	$(call php, composer install -o)
 	@$(call php, /bin/sh ./scripts/makefile/upgrade-status-validation.sh)
+else
+	@echo "scripts/makefile/upgrade-status-validation.sh file does not exist"
+endif
 
 ## Validate newline at the end of files
 newlineeof:

--- a/scripts/makefile/tests.mk
+++ b/scripts/makefile/tests.mk
@@ -93,6 +93,13 @@ drupalcheckval:
 	$(call php, vendor/bin/drupal-check -V)
 	$(call php, vendor/bin/drupal-check -ad -vv -n --no-progress web/modules/custom/)
 
+## Validate drupal-rector
+drupalrectorval:
+	@echo "Drupal-check validation..."
+	$(call php, composer install -o)
+	$(call php, vendor/bin/rector -V)
+	$(call php, vendor/bin/rector process --dry-run --no-progress-bar web/modules/custom web/themes/custom)
+
 ## Validate newline at the end of files
 newlineeof:
 ifneq ("$(wildcard scripts/makefile/newlineeof.sh)","")

--- a/scripts/makefile/upgrade-status-validation.sh
+++ b/scripts/makefile/upgrade-status-validation.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env sh
 
+# Enable Upgrade Status module
+drush en -y upgrade_status
+
 # Search for no issues message
 REPORT=$(drush us-a --all --ignore-contrib --ignore-uninstalled)
 IS_VALID=$(echo "$REPORT" | grep "No known issues found.")

--- a/scripts/makefile/upgrade-status-validation.sh
+++ b/scripts/makefile/upgrade-status-validation.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+# Search for no issues message
+REPORT=$(drush us-a --all --ignore-contrib --ignore-uninstalled)
+IS_VALID=$(echo "$REPORT" | grep "No known issues found.")
+
+# Exit1 and alert if message not found
+if [ -z "$IS_VALID" ]; then
+  printf "There are \033[1mmessage(s)\033[0m in Upgrade Status report to fix :\n"
+	echo -e "$REPORT"
+	exit 1
+else
+  echo -e "Status report is valid : No error listed"
+	exit 0
+fi

--- a/scripts/makefile/upgrade-status-validation.sh
+++ b/scripts/makefile/upgrade-status-validation.sh
@@ -9,10 +9,11 @@ IS_VALID=$(echo "$REPORT" | grep "No known issues found.")
 
 # Exit1 and alert if message not found
 if [ -z "$IS_VALID" ]; then
-  printf "There are \033[1mmessage(s)\033[0m in Upgrade Status report to fix :\n"
+  printf "There are \033[1missue(s)\033[0m in Upgrade Status report to fix : \n- Go to \033[1m/admin/reports/upgrade-status\033[0m for more details\n"
 	echo -e "$REPORT"
 	exit 1
 else
-  echo -e "Status report is valid : No error listed"
+	drush pmu upgrade_status -y
+	echo -e "Status report is valid : No error listed"
 	exit 0
 fi

--- a/web/profiles/sdd/sdd.info.yml
+++ b/web/profiles/sdd/sdd.info.yml
@@ -1,7 +1,7 @@
 name: SDD
 type: profile
 description: 'Skill drupal development installation profile for content projects'
-core: 8.x
+core_version_requirement: ^8 || ^9
 
 dependencies:
   - automated_cron


### PR DESCRIPTION
drupal-check is going deprecated as maintainer stated at https://github.com/mglaman/drupal-check/issues/172#issue-616031763 in favor of tools like [Upgrade Status](https://www.drupal.org/project/upgrade_status)
Behind the scenes Upgrade status uses the same phpstam rules so this module is like an extended version of drupal-check

This PR is also including [Drupal Rector](https://www.drupal.org/project/rector) which helps for d9 readiness.