### PR TITLE
Enable assertions by default

### DIFF
--- a/docker/docker-compose.override.yml.default
+++ b/docker/docker-compose.override.yml.default
@@ -30,6 +30,8 @@ services:
 #    depends_on:
 #      - mysql
 #      - postgresql
+# Catch code assertions "development" mode. https://www.php.net/manual/en/function.assert.php
+    command: php-fpm7 -F -d zend.assertions=1
 # Uncomment next line if you need PHP XDebug.
 #    command: php-fpm81 -F -dzend.assertions=1 -dzend_extension=xdebug.so
 #    command: php-fpm81 -F -dzend.assertions=1 -dopcache.jit_buffer_size=20M


### PR DESCRIPTION
Drupal core using https://www.php.net/manual/en/function.assert.php to catch bugs early

As SDC supposed for development, better to have this flag fired

https://www.drupal.org/docs/drupal-apis/runtime-assertions#s-assertions-in-drupal