### PR TITLE
Check if chrome container exists before attempting to stop it.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -160,9 +160,6 @@
         "Errors when using with modules that alter a section's contextual menu": "https://www.drupal.org/files/issues/2020-05-22/3106939-4.patch",
         "Indicate Drupal 8/9 compatibility via core_version_requirement": "https://www.drupal.org/files/issues/2020-05-22/d9_compatibility-3138698-4.patch"
       },
-      "drupal/manage_display": {
-        "Drupal 9 compatibility": "https://www.drupal.org/files/issues/2020-04-01/manage_display.d9.3124061-2.patch"
-      },
       "drupal/menu_link_attributes": {
         "Add missing schema for menu_link_attributes": "https://patch-diff.githubusercontent.com/raw/yannickoo/menu_link_attributes/pull/52.patch"
       },

--- a/scripts/makefile/tests.mk
+++ b/scripts/makefile/tests.mk
@@ -166,7 +166,10 @@ browser_driver:
 
 ## Stop browser driver
 browser_driver_stop:
-	docker stop $(COMPOSE_PROJECT_NAME)_chrome
+	if [ ! -z `docker ps -f 'name=$(COMPOSE_PROJECT_NAME)_chrome' --format '{{.Names}}'` ]; then \
+		echo 'Stopping browser driver.'; \
+		docker stop $(COMPOSE_PROJECT_NAME)_chrome; \
+	fi
 
 ## Create a high number of random content
 contentgen:


### PR DESCRIPTION
`make browser_driver_stop` closes docker container without validating it actually exists then when it doesn't exist we get an error like

```
Error response from daemon: No such container: exerpwlp_chrome
scripts/makefile/tests.mk:145: recipe for target 'browser_driver_stop' failed
make: *** [browser_driver_stop] Error 1
```
In CI pipeline we get this scenario when `make behat` completes succesfully and `after_scripts` runs `make browser_driver_stop` which is a safeguard for errors in `make behat`

This PR adds validation to prevent the aforementioned error.