### PR TITLE
Fix CI issues on upgrade status validation

### DIFF
--- a/scripts/makefile/upgrade-status-validation.sh
+++ b/scripts/makefile/upgrade-status-validation.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env sh
 
 # Enable Upgrade Status module
-drush en -y upgrade_status
+drush pm:enable upgrade_status -y
+
+# Clear drush cache
+drush cc drush
 
 # Search for no issues message
-REPORT=$(drush us-a --all --ignore-contrib --ignore-uninstalled)
+REPORT=$(drush upgrade_status:analyze --all --ignore-contrib --ignore-uninstalled)
 IS_INVALID=$(echo "$REPORT" | grep "FILE:")
 
 # Exit 1 and alert if at least one file was reported.
 if [ -z "$IS_INVALID" ]; then
-	drush pmu upgrade_status -y
 	echo -e "Status report is valid : No error listed"
 	exit 0
 else


### PR DESCRIPTION
1. Upgrade status validation runs in parallel with config inspector. Sometimes config inspector finds upgrade status config but the module is being uninstalled in parallel so we get error in config inspector. For this issue I changed script to leave `upgrade_status` enabled as it will only be on test RA env.

2. In some cases drush doesn't recognize commands from `upgrade_status` module so I added `drush cc drush` to make sure drush cache is rebuilt to include the new commands.

3. Replaced `drush us-a` by `upgrade_status:analyze` to use drush 9+ format which is also more explicit and readable in script.