### PR TITLE
Adding repos of outdated modules to apply d9 patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,11 @@ back:
 ifeq ($(INSTALL_DEV_DEPENDENCIES), TRUE)
 	@echo "INSTALL_DEV_DEPENDENCIES=$(INSTALL_DEV_DEPENDENCIES)"
 	@echo "Installing composer dependencies, including dev ones"
-	$(call php, composer install -o)
+	$(call php, composer install --prefer-dist -o)
 else
 	@echo "INSTALL_DEV_DEPENDENCIES set to FALSE or missing from .env"
 	@echo "Installing composer dependencies, without dev ones"
-	$(call php, composer install -o --no-dev)
+	$(call php, composer install --prefer-dist -o --no-dev)
 endif
 	$(call php, composer create-required-files)
 

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,11 @@ back:
 ifeq ($(INSTALL_DEV_DEPENDENCIES), TRUE)
 	@echo "INSTALL_DEV_DEPENDENCIES=$(INSTALL_DEV_DEPENDENCIES)"
 	@echo "Installing composer dependencies, including dev ones"
-	$(call php, composer install --prefer-dist -o)
+	$(call php, composer install -o)
 else
 	@echo "INSTALL_DEV_DEPENDENCIES set to FALSE or missing from .env"
 	@echo "Installing composer dependencies, without dev ones"
-	$(call php, composer install --prefer-dist -o --no-dev)
+	$(call php, composer install -o --no-dev)
 endif
 	$(call php, composer create-required-files)
 

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,23 @@
     {
       "type": "composer",
       "url": "https://packages.drupal.org/8"
+    },
+    {
+      "type": "package",
+      "package": {
+        "name": "drupal/lb_ux",
+        "version": "dev-8.x-1.x",
+        "type": "drupal-module",
+        "source": {
+          "url": "https://git.drupalcode.org/project/lb_ux.git",
+          "type": "git",
+          "reference": "8.x-1.x"
+        }
+      }
+    },
+    {
+      "type": "vcs",
+      "url": "https://git.drupalcode.org/project/panels_everywhere.git"
     }
   ],
   "require": {
@@ -32,13 +49,13 @@
     "drupal/layout_builder_modal": "^1.1",
     "drupal/layout_builder_restrictions": "^2.7",
     "drupal/layout_library": "^1.0@beta",
-    "drupal/lb_ux": "1.x-dev",
+    "drupal/lb_ux": "dev-8.x-1.x",
     "drupal/manage_display": "^1.0@alpha",
     "drupal/menu_admin_per_menu": "^1.1",
     "drupal/menu_link_attributes": "1.x-dev",
     "drupal/page_manager": "^4.0.0-beta6",
     "drupal/panels": "^4.6",
-    "drupal/panels_everywhere": "4.x-dev",
+    "drupal/panels_everywhere": "dev-8.x-4.x",
     "drupal/paragraphs": "^1.11",
     "drupal/pathauto": "^1.8",
     "drupal/rabbit_hole": "^1.0.0-beta7",
@@ -72,8 +89,6 @@
   "config": {
     "sort-packages": true,
     "preferred-install": {
-      "drupal/lb_ux": "source",
-      "drupal/panels_everywhere": "source",
       "*": "dist"
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,17 @@
       }
     },
     {
-      "type": "vcs",
-      "url": "https://git.drupalcode.org/project/panels_everywhere.git"
+      "type": "package",
+      "package": {
+        "name": "drupal/panels_everywhere",
+        "version": "dev-8.x-4.x",
+        "type": "drupal-module",
+        "source": {
+          "url": "https://git.drupalcode.org/project/panels_everywhere.git",
+          "type": "git",
+          "reference": "8.x-4.x"
+        }
+      }
     }
   ],
   "require": {
@@ -89,6 +98,8 @@
   "config": {
     "sort-packages": true,
     "preferred-install": {
+      "drupal/lb_ux": "source",
+      "drupal/panels_everywhere": "source",
       "*": "dist"
     }
   },


### PR DESCRIPTION
1. `panels_everywhere` and `lb_ux` modules weren't updated for d9 compatibility yet so composer shows conflict between core 9 and these modules. To fix the issue I added their repos in composer.json so in this way we can grab the code from repo and apply the proper patches to make them compatible with d9.

2. Removed `--prefer-dist` parameter cause now we have this setting in composer.json config, see https://github.com/skilld-labs/skilld-docker-container/blob/d9_patches_outdated_repos/composer.json#L92