### PR TITLE
Add "View unpublished paragraphs" permission to Contributor role.

### DIFF
--- a/web/profiles/sdd/config/install/user.role.contributor.yml
+++ b/web/profiles/sdd/config/install/user.role.contributor.yml
@@ -112,3 +112,4 @@ permissions:
   - 'view own unpublished media'
   - 'view restricted block content'
   - 'view the administration theme'
+  - 'view unpublished paragraphs'


### PR DESCRIPTION
A Contributor role user can't see unpublished paragraphs.