### PR TITLE
Create new stage + Start storybook only on success

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,7 @@ stages:
   - sniffers
   - prepare
   - deploy
+  - storybook
   - tests
   - reports
 
@@ -196,7 +197,6 @@ prepare:front:
   dependencies:
     - prepare:back
     - prepare:front
-  allow_failure: false
   <<: *runner_tag_selection
   <<: *only_branches
 
@@ -230,7 +230,7 @@ stop_review:
   <<: *only_branches
 
 deploy:storybook:
-  stage: deploy
+  stage: storybook
   environment:
     url: https://${CI_ENVIRONMENT_SLUG}-${CI_PROJECT_PATH_SLUG}.${REVIEW_DOMAIN}
     name: review/$CI_COMMIT_REF_NAME
@@ -245,8 +245,6 @@ deploy:storybook:
   <<: *runner_tag_selection
   <<: *only_branches
   <<: *only_var_theme
-  when: always
-
 
 test:behat:
   stage: tests
@@ -270,7 +268,6 @@ test:behat:
     when: script_failure
   dependencies:
   - deploy:review
-  allow_failure: false
   <<: *runner_tag_selection
   <<: *only_branches
 

--- a/web/profiles/sdd/config/install/user.role.contributor.yml
+++ b/web/profiles/sdd/config/install/user.role.contributor.yml
@@ -112,3 +112,4 @@ permissions:
   - 'view own unpublished media'
   - 'view restricted block content'
   - 'view the administration theme'
+  - 'view unpublished paragraphs'


### PR DESCRIPTION
### Goal

* Prevent storybook from starting before build is done (when manual for example). In this case storybook build fails 

### Changes
- Updated the "when" of storybook deploy to "on_success" so that it doesn't start when there is a manual job pending but only when it's successful. 

- Added a "allow_failure: false" to receive start only when successful

-  Created new stage specific to the storybook ("on_success" only works when checking full stage and not individual pipeline"