### PR TITLE
patch "Expose Layout Builder data to REST and JSON:API"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -167,7 +167,8 @@
         "Claro Modal dialog style update": "https://www.drupal.org/files/issues/2020-05-19/3023311-93.patch",
         "Claro Media and media library": "https://www.drupal.org/files/issues/2020-03-30/media-and-media-library-3062751-18.patch",
         "Callers of LayoutEntityHelperTrait::getEntitySections() do not account for the view mode": "https://www.drupal.org/files/issues/2019-06-20/3008924-5.patch",
-        "Claro + layout builder messages display additional icon in top left corner": "https://www.drupal.org/files/issues/2020-05-28/claro_layout_builder_extra_icon-3143237-4.patch"
+        "Claro + layout builder messages display additional icon in top left corner": "https://www.drupal.org/files/issues/2020-05-28/claro_layout_builder_extra_icon-3143237-4.patch",
+        "Expose Layout Builder data to REST and JSON:API" : "https://www.drupal.org/files/issues/2020-07-07/2942975-116.patch"
       },
       "drush/drush": {
         "Import multiple custom translation po files": "https://patch-diff.githubusercontent.com/raw/drush-ops/drush/pull/4251.patch"


### PR DESCRIPTION
Allow to export default content when using layout builder per node