### PR TITLE
Add profiles make tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ networks:
 * `make front` - Builds frontend tasks.
 * `make lint` - Runs frontend linters.
 * `make storybook` - Runs storybook in current theme.
+* `make blackfire` - Adds and enables blackfire.io php extension, needs [configuration](https://blackfire.io/docs/configuration/php) in docker-composer override.yml.
+* `make newrelic` - Adds and enables newrelic.com php extension, needs [configuration](https://docs.newrelic.com/docs/agents/php-agent/getting-started/introduction-new-relic-php#configuration) in docker-composer.override.yml.
 
 #### Additional goals
 

--- a/docker/docker-compose.override.yml.default
+++ b/docker/docker-compose.override.yml.default
@@ -6,12 +6,35 @@ services:
   php:
     environment:
       COMPOSER_MEMORY_LIMIT: "-1"
+#      BLACKFIRE_CLIENT_ID: x
+#      BLACKFIRE_CLIENT_TOKEN: x
+#      NEW_RELIC_LICENSE_KEY: x
+#      NEW_RELIC_APPNAME: "${COMPOSE_PROJECT_NAME}"
     volumes:
       - "./90-mail.ini:/etc/php7/conf.d/90-mail.ini:z"
 #    depends_on:
 #      - mysql
 # Uncomment next line if you need PHP XDebug.
 #    command: php-fpm7 -F -d zend_extension=xdebug.so
+
+# Get access keys from https://blackfire.io/my/profiles
+# Then download extension using "make blackfire"
+
+#  blackfire:
+#    image: blackfire/blackfire
+#    container_name: "${COMPOSE_PROJECT_NAME}_blackfire"
+#    environment:
+#      BLACKFIRE_SERVER_ID: x
+#      BLACKFIRE_SERVER_TOKEN: x
+#      BLACKFIRE_LOG_LEVEL: 1
+#    networks:
+#      - front
+
+#  newrelic:
+#    image: newrelic/php-daemon
+#    container_name: "${COMPOSE_PROJECT_NAME}_newrelic"
+#    networks:
+#      - front
 
 #  adminer:
 #    image: dockette/adminer:mysql-php7

--- a/scripts/makefile/blackfire.sh
+++ b/scripts/makefile/blackfire.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+
+# installs backfire/io probe extension
+
+# use `php -i | grep "additional .ini"` to get it
+PHP_INI_DIR=/etc/php7/conf.d
+
+set -e
+
+env_vars='BLACKFIRE_CLIENT_ID BLACKFIRE_CLIENT_TOKEN'
+
+for var in $env_vars; do
+	eval "val=\${$var}"
+	if [ -z "${val}" -o "${val}" = 'x' ]; then
+		echo "Configure ${var} in docker-compose.override.yml"
+		echo "Visit https://blackfire.io/my/settings/credentials to get credentials"; exit 1
+	fi
+done
+
+version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+	&& curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/amd64/$version \
+	&& mkdir -p /tmp/blackfire \
+	&& tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+	&& mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get ('extension_dir');")/blackfire.so \
+	&& printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/blackfire.ini \
+	&& rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz

--- a/scripts/makefile/newrelic.sh
+++ b/scripts/makefile/newrelic.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+
+# installs newrelic.com agent extension
+
+# use `php -i | grep "additional .ini"` to get it
+PHP_INI_DIR=/etc/php7/conf.d
+
+# get the latest version from https://download.newrelic.com/php_agent/archive/
+NEW_RELIC_AGENT_VERSION="${NEW_RELIC_AGENT_VERSION:-9.12.0.268}"
+# change it to 'linux' if docker image is not based on Alpinelinux
+NEW_RELIC_LINUX=${NEW_RELIC_LINUX:-linux-musl}
+
+set -e
+
+env_vars='NEW_RELIC_APPNAME NEW_RELIC_LICENSE_KEY'
+
+for var in $env_vars; do
+	eval "val=\${$var}"
+	if [ -z "${val}" -o "${val}" = 'x' ]; then
+		echo "Configure ${var} in docker-compose.override.yml"
+		echo "Visit https://newrelic.com 'Account settings' to get the key"; exit 1;
+	fi
+done
+
+curl -L https://download.newrelic.com/php_agent/archive/${NEW_RELIC_AGENT_VERSION}/newrelic-php5-${NEW_RELIC_AGENT_VERSION}-${NEW_RELIC_LINUX}.tar.gz | tar -C /tmp -zx \
+	&& export NR_INSTALL_USE_CP_NOT_LN=1 \
+	&& export NR_INSTALL_SILENT=1 \
+	&& /tmp/newrelic-php5-${NEW_RELIC_AGENT_VERSION}-${NEW_RELIC_LINUX}/newrelic-install install \
+	&& rm -rf /tmp/newrelic-php5-* /tmp/nrinstall*
+
+sed -i -e s/\"REPLACE_WITH_REAL_KEY\"/${NEW_RELIC_LICENSE_KEY}/ \
+	-e s/newrelic.appname[[:space:]]=[[:space:]].\*/newrelic.appname="${NEW_RELIC_APPNAME}"/ \
+	$PHP_INI_DIR/newrelic.ini
+#	-e s/\;newrelic.daemon.address[[:space:]]=[[:space:]].\*/newrelic.daemon.address="${NEW_RELIC_DAEMON_ADDRESS}"/ \

--- a/scripts/makefile/tests.mk
+++ b/scripts/makefile/tests.mk
@@ -187,3 +187,22 @@ sniffers: | clang compval phpcs newlineeof
 ## Run all tests & validations (including sniffers)
 tests: | sniffers cinsp drupalrectorval upgradestatusval behat watchdogval statusreportval
 
+blackfire:
+ifneq ("$(wildcard scripts/makefile/blackfire.sh)","")
+	$(call php-0, /bin/sh ./scripts/makefile/blackfire.sh)
+	$(call php-0, kill -USR2 1)
+	@echo "Blackfire extension enabled"
+else
+	@echo "scripts/makefile/blackfire.sh file does not exist"
+	@exit 1
+endif
+
+newrelic:
+ifneq ("$(wildcard scripts/makefile/newrelic.sh)","")
+	$(call php-0, /bin/sh ./scripts/makefile/newrelic.sh)
+	$(call php-0, kill -USR2 1)
+	@echo "NewRelic extension enabled"
+else
+	@echo "scripts/makefile/newrelic.sh file does not exist"
+	@exit 1
+endif


### PR DESCRIPTION
Configuration require to setup user's keys from https://blackfire.io/my/settings/credentials

In `docker/docker-compose.override.yml` uncomment and fill values for
- `BLACKFIRE_CLIENT_ID` and `BLACKFIRE_CLIENT_TOKEN` for `php` service
- `BLACKFIRE_SERVER_ID` and `BLACKFIRE_SERVER_TOKEN` for `blackfire` service

After that make sure `docker-compose up -d` that `blackfire` container created and running
Then use `make blackfire` to install probe agent and use it for php-fpm

Use `BLACKFIRE_LOG_LEVEL: 4` to debug agent or probe

Details https://blackfire.io/docs/configuration/php

