### PR TITLE
Keep composer cache in local directory

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -19,6 +19,7 @@ IMAGE_DRIVER=zenika/alpine-chrome
 CLEAR_FRONT_PACKAGES=no
 ADD_PHP_EXT=
 #ADD_PHP_EXT=php7-pdo_pgsql postgresql-client postgresql-contrib  gnu-libiconv wkhtmltopdf
+COMPOSER_HOME_CACHE=../.cache/composer
 MAIN_DOMAIN_NAME=docker.localhost
 DB_URL=sqlite:./../.cache/d8.sqlite
 # Faster but data will be lost on php container recreation

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -179,7 +179,7 @@ prepare:front:
     - echo "CI_PROJECT_NAME=${CI_PROJECT_NAME}"
     - echo "REVIEW_DOMAIN=${REVIEW_DOMAIN}"
     - mkdir -p ${BUILD_DIR}
-    - rsync -ah --exclude=.git --delete ./ ${BUILD_DIR}
+    - rsync -ah --exclude=.git --exclude=.cache --delete ./ ${BUILD_DIR}
     - cd ${BUILD_DIR}
     - echo "COMPOSE_PROJECT_NAME=${CI_PROJECT_NAME}-review-${CI_COMMIT_REF_SLUG}" >> .env.default
     - echo "MAIN_DOMAIN_NAME=${CI_ENVIRONMENT_SLUG}-${CI_PROJECT_PATH_SLUG}.${REVIEW_DOMAIN}" >> .env.default

--- a/docker/docker-compose.override.yml.default
+++ b/docker/docker-compose.override.yml.default
@@ -6,11 +6,13 @@ services:
   php:
     environment:
       COMPOSER_MEMORY_LIMIT: "-1"
+      COMPOSER_HOME: /home/www-data/.composer
 #      BLACKFIRE_CLIENT_ID: x
 #      BLACKFIRE_CLIENT_TOKEN: x
 #      NEW_RELIC_LICENSE_KEY: x
 #      NEW_RELIC_APPNAME: "${COMPOSE_PROJECT_NAME}"
     volumes:
+      - "${COMPOSER_HOME_CACHE}:/home/www-data/.composer:z"
       - "./90-mail.ini:/etc/php7/conf.d/90-mail.ini:z"
 #    depends_on:
 #      - mysql


### PR DESCRIPTION
To speed up site building we can keep composer cache in a local directory to be reused on future builds