### PR TITLE
Require docker 17.12+

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@
 ## Quickstart
 
 * Install docker for <a href="https://docs.docker.com/install/" target="_blank">Linux</a>, <a href="https://docs.docker.com/docker-for-mac/install/" target="_blank">Mac</a>, <a href="https://docs.docker.com/docker-for-windows/install/" target="_blank">Windows</a>
-  *  Check <a href="https://docs.docker.com/install/linux/linux-postinstall/" target="_blank">post-installation steps for Linux</a>
-* Install <a href="https://docs.docker.com/compose/install/" target="_blank">docker compose</a>
+  *  Check <a href="https://docs.docker.com/install/linux/linux-postinstall/" target="_blank">post-installation steps for Linux</a> version 17.12.0 or later
+* Install <a href="https://docs.docker.com/compose/install/" target="_blank">docker compose</a> version 1.21.0 or later
 
 * Copy **.env.default** to **.env**, more information about enviroment file can be found <a href="https://docs.docker.com/compose/env-file/" target="_blank">docs.docker.com</a>
 * Copy **docker-compose.override.yml.default** to **docker-compose.override.yml**, update parts you want to overwrite.

--- a/docker/docker-compose.override.yml.default
+++ b/docker/docker-compose.override.yml.default
@@ -1,4 +1,4 @@
-version: "2.1"
+version: "2.4"
 
 services:
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2.1"
+version: "2.4"
 
 services:
 


### PR DESCRIPTION
See https://docs.docker.com/compose/compose-file/compose-versioning/#version-24

The main points is
- healthchecks
- runtime and platform options
- unlocks 3.x upgrade to named volumes and more

1.13 released in Jan'17 https://www.docker.com/blog/whats-new-in-docker-1-13/

Closes #153 