### PR TITLE
Allow bower-asset packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,10 @@
     {
       "type": "composer",
       "url": "https://packages.drupal.org/8"
+    },
+    {
+      "type": "composer",
+      "url": "https://asset-packagist.org"
     }
   ],
   "require": {


### PR DESCRIPTION
Some packages like drupal/lightning_media require bower-assets. To allow installing bower-assets we need to include a new repository source which is provided in this PR.