### PR TITLE
Fix upgrade status validation errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,8 @@
     "drupal/upgrade_rector": "^1",
     "drupal/upgrade_status": "^3",
     "espend/behat-placeholder-extension": "^1.1",
-    "genesis/behat-fail-aid": "^2.1"
+    "genesis/behat-fail-aid": "^2.1",
+    "phpunit/phpunit": "^9"
   },
   "conflict": {
     "drupal/drupal": "*"
@@ -136,7 +137,9 @@
         "tests",
         "src/Tests"
       ],
-      "exclude": []
+      "exclude": [
+        "web/core/tests"
+      ]
     },
     "patches": {
       "drupal/core": {


### PR DESCRIPTION
Upgrade status validation currently shows some errors like:

`PHP Warning:  require_once(/var/www/html/web/core/tests/bootstrap.php): failed to open stream: No such file or directory in /var/www/html/vendor/mglaman/phpstan-drupal/src/Drupal/DrupalAutoloader.php on line 103
Warning: require_once(/var/www/html/web/core/tests/bootstrap.php): failed to open stream: No such file or directory in /var/www/html/vendor/mglaman/phpstan-drupal/src/Drupal/DrupalAutoloader.php on line 103
PHP Fatal error:  require_once(): Failed opening required '/var/www/html/web/core/tests/bootstrap.php' (include_path='/var/www/html/vendor/pear/archive_tar:/var/www/html/vendor/pear/console_getopt:/var/www/html/vendor/pear/pear-core-minimal/src:/var/www/html/vendor/pear/pear_exception:.:/usr/share/php7') in /var/www/html/vendor/mglaman/phpstan-drupal/src/Drupal/DrupalAutoloader.php on line 103
Fatal error: require_once(): Failed opening required '/var/www/html/web/core/tests/bootstrap.php' (include_path='/var/www/html/vendor/pear/archive_tar:/var/www/html/vendor/pear/console_getopt:/var/www/html/vendor/pear/pear-core-minimal/src:/var/www/html/vendor/pear/pear_exception:.:/usr/share/php7') in /var/www/html/vendor/mglaman/phpstan-drupal/src/Drupal/DrupalAutoloader.php on line 103
 [error]  PHPStan failed: Array
(
)
`

And also:

`PHP Warning:  Class 'PHPUnit\Framework\AssertionFailedError' not found in /var/www/html/web/core/tests/bootstrap.php on line 192
Warning: Class 'PHPUnit\Framework\AssertionFailedError' not found in /var/www/html/web/core/tests/bootstrap.php on line 192
PHP Warning:  Class 'PHPUnit\Framework\Constraint\Count' not found in /var/www/html/web/core/tests/bootstrap.php on line 193
Warning: Class 'PHPUnit\Framework\Constraint\Count' not found in /var/www/html/web/core/tests/bootstrap.php on line 193
PHP Warning:  Class 'PHPUnit\Framework\Error\Error' not found in /var/www/html/web/core/tests/bootstrap.php on line 194
Warning: Class 'PHPUnit\Framework\Error\Error' not found in /var/www/html/web/core/tests/bootstrap.php on line 194
PHP Warning:  Class 'PHPUnit\Framework\Error\Warning' not found in /var/www/html/web/core/tests/bootstrap.php on line 195
Warning: Class 'PHPUnit\Framework\Error\Warning' not found in /var/www/html/web/core/tests/bootstrap.php on line 195
PHP Warning:  Class 'PHPUnit\Framework\ExpectationFailedException' not found in /var/www/html/web/core/tests/bootstrap.php on line 196
Warning: Class 'PHPUnit\Framework\ExpectationFailedException' not found in /var/www/html/web/core/tests/bootstrap.php on line 196
PHP Warning:  Class 'PHPUnit\Framework\Exception' not found in /var/www/html/web/core/tests/bootstrap.php on line 197
Warning: Class 'PHPUnit\Framework\Exception' not found in /var/www/html/web/core/tests/bootstrap.php on line 197
PHP Warning:  Class 'PHPUnit\Framework\MockObject\Matcher\InvokedRecorder' not found in /var/www/html/web/core/tests/bootstrap.php on line 198
Warning: Class 'PHPUnit\Framework\MockObject\Matcher\InvokedRecorder' not found in /var/www/html/web/core/tests/bootstrap.php on line 198
PHP Warning:  Class 'PHPUnit\Framework\SkippedTestError' not found in /var/www/html/web/core/tests/bootstrap.php on line 199
Warning: Class 'PHPUnit\Framework\SkippedTestError' not found in /var/www/html/web/core/tests/bootstrap.php on line 199
PHP Warning:  Class 'PHPUnit\Framework\TestCase' not found in /var/www/html/web/core/tests/bootstrap.php on line 200
Warning: Class 'PHPUnit\Framework\TestCase' not found in /var/www/html/web/core/tests/bootstrap.php on line 200
PHP Warning:  Class 'PHPUnit\Util\Test' not found in /var/www/html/web/core/tests/bootstrap.php on line 201
Warning: Class 'PHPUnit\Util\Test' not found in /var/www/html/web/core/tests/bootstrap.php on line 201
PHP Warning:  Class 'PHPUnit\Util\Xml' not found in /var/www/html/web/core/tests/bootstrap.php on line 202
Warning: Class 'PHPUnit\Util\Xml' not found in /var/www/html/web/core/tests/bootstrap.php on line 202
Error thrown in /var/www/html/web/core/tests/Drupal/TestTools/PhpUnitCompatibility/RunnerVersion.php on line 27 while loading bootstrap file /var/www/html/vendor/mglaman/phpstan-drupal/drupal-autoloader.php: Class 'PHPUnit\Runner\Version' not found
 [error]  PHPStan failed: Array
(
)
`
These errors happen cause we cleaned `core/tests` folder and we miss PHPUnit library so I added cleanup exception and added PHPUnit as dev dependency.