### PR TITLE
Fix tag pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,11 +152,11 @@ prepare:back:
       - web/
       - drush/contrib/
   <<: *runner_tag_selection
-  <<: *only_branches
 
 prepare:front:
   stage: prepare
   script:
+    - make front-install
     - make front-build
   dependencies:
     - sniffers:front


### PR DESCRIPTION
Tag pipelines were failing cause:
1. In `prepare:front` we need `make front-install` to install packages before `make front-build`
2. `prepare:back` is set to only run on branches but we also need it for tags.