### PR TITLE
Adding text mapping example to behat extension config

### DIFF
--- a/behat.default.yml
+++ b/behat.default.yml
@@ -28,6 +28,10 @@ default:
         mode: default
         autoClean: true
     Drupal\DrupalExtension:
+      # text:
+      #   log_in: "Log in"
+      #   password_field: "Password"
+      #   username_field: "Login by username/email address"
       blackbox: ~
       api_driver: 'drupal'
       drupal:


### PR DESCRIPTION
Needed when field labels differs from native EN drupal