### PR TITLE
Prepare to composer 2 switch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,8 +60,7 @@
     "drupal/views_bulk_operations": "^3.9",
     "drupal/webform": "^6",
     "drush/drush": "^10.1.0",
-    "skilldlabs/drupal-cleanup": "^1",
-    "zaporylie/composer-drupal-optimizations": "^1.2"
+    "skilldlabs/drupal-cleanup": "^1"
   },
   "require-dev": {
     "dmore/behat-chrome-extension": "^1.3",
@@ -176,7 +175,7 @@
         "Add missing schema for gin_login": "https://www.drupal.org/files/issues/2021-01-13/gin_login-config_schema-3192526-8.patch"
       },
       "drupal/upgrade_status": {
-        "Exclude node_modules from scan": "https://www.drupal.org/files/issues/2020-08-14/3162997-8.patch"
+        "Exclude node_modules from scan": "https://www.drupal.org/files/issues/2021-03-04/3162997-20.patch"
       }
     }
   }


### PR DESCRIPTION
- use fresh patch for upgrade status https://www.drupal.org/project/upgrade_status/issues/3162997#comment-14019319
- remove useless for composer 2.x `zaporylie/composer-drupal-optimizations` 