### PR TITLE
Fixing hookupdateval CI script to catch issues when pushing multiple …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Add utility functions and scripts to the container
 include scripts/makefile/*.mk
 
-.PHONY: all fast allfast provision si exec exec0 down clean dev drush info phpcs phpcbf hooksymlink clang cinsp compval watchdogval drupalrectorval upgradestatusval behat sniffers tests front front-install front-build clear-front lintval lint storybook back behatdl behatdi browser_driver browser_driver_stop statusreportval contentgen newlineeof localize local-settings redis-settings content
+.PHONY: all fast allfast provision si exec exec0 down clean dev drush info phpcs phpcbf hooksymlink clang cinsp compval watchdogval drupalrectorval upgradestatusval behat sniffers tests front front-install front-build clear-front lintval lint storybook back behatdl behatdi browser_driver browser_driver_stop statusreportval contentgen newlineeof localize local-settings redis-settings content hookupdateval
 .DEFAULT_GOAL := help
 
 # https://stackoverflow.com/a/6273809/1826109

--- a/scripts/makefile/hookupdateval.sh
+++ b/scripts/makefile/hookupdateval.sh
@@ -1,27 +1,38 @@
 #!/usr/bin/env sh
+# set -x
 
-# Count config updates to watch for
-FIELD_STORAGE_COUNT=$(git show --name-status | grep "^M" | grep -c field.storage )
-EXTENSIONS_DISABLED_COUNT=$(git show --shortstat -- config/*/*core.extension* | grep -c deletion)
+# Get name of parent branch...
+if [ -z "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME" ]; then
+  # ... when not in Gitlab CI
+  PARENT_BRANCH=$(git show-branch | sed "s/].*//" | grep "\*" | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -n1 | sed "s/^.*\[//")
+else
+  # ... when in Gitlab CI
+  PARENT_BRANCH=$CI_MERGE_REQUEST_TARGET_BRANCH_NAME
+fi
 
-if [ "$FIELD_STORAGE_COUNT" -gt "0" ] || [ "$EXTENSIONS_DISABLED_COUNT" -gt "0" ]; then
+# Diff current branch against parent branch and make validation
+git fetch -q origin "$PARENT_BRANCH"
+FIELD_STORAGE_CHANGE_COUNT=$(git diff origin/"$PARENT_BRANCH" --name-only --diff-filter=M | grep -c field.storage)
+CORE_EXTENSION_DELETION_COUNT=$(git diff origin/"$PARENT_BRANCH" --shortstat -- config/*/*core.extension* | grep -c deletion)
+
+if [ "$FIELD_STORAGE_CHANGE_COUNT" -gt "0" ] || [ "$CORE_EXTENSION_DELETION_COUNT" -gt "0" ]; then
   # If watched config was updated, we need new hook_updates in install file
-  UPDATE_COUNT=$(git show web/modules/custom/*.install | grep "^\+" | grep -c _update_ )
-  if [ "$UPDATE_COUNT" -gt "0" ]; then
+  HOOKUPDATE_ADDITION_COUNT=$(git diff origin/"$PARENT_BRANCH" web/modules/custom/*.install | grep "^\+" | grep -c _update_ )
+  if [ "$HOOKUPDATE_ADDITION_COUNT" -gt "0" ]; then
     printf "hook_update_N() has been included for watched config changes.\n"
     exit 0
   else
     printf "\033[1mERROR: hook_update_N() missing for next reason(s):\n"
-    if [ "$FIELD_STORAGE_COUNT" -gt "0" ]; then
+    if [ "$FIELD_STORAGE_CHANGE_COUNT" -gt "0" ]; then
       printf " - A field storage config update has occured which requires a hook_update to be properly deployable on live site.\n"
     fi
-    if [ "$EXTENSIONS_DISABLED_COUNT" -gt "0" ]; then
+    if [ "$CORE_EXTENSION_DELETION_COUNT" -gt "0" ]; then
       printf " - Some module has been disabled (and possibly removed), so, need hook_update which will remove all modules data during deploy on live site.\n"
     fi
     printf "Please include missing hook_updates(s)\n"
     exit 1
   fi
 else
-  echo "OK : No change requires a hook_update_N()\n"
+  printf "OK : No change requires a hook_update_N()\n"
   exit 0
 fi

--- a/scripts/makefile/tests.mk
+++ b/scripts/makefile/tests.mk
@@ -62,13 +62,13 @@ compval:
 	# Can't use --strict cause we need dev versions for d9 compatibility
 	@docker run --rm -v $(CURDIR):/mnt -w /mnt $(IMAGE_PHP) composer validate
 
-## Validate hook_update_N()
+## Validate if hook_update_N() are required
 hookupdateval:
 ifneq ("$(wildcard scripts/makefile/hookupdateval.sh)","")
 	@echo "hook_update_N() validation..."
 	@/bin/sh ./scripts/makefile/hookupdateval.sh
 else
-	@echo "scripts/makefile/hookupdateval.sh.sh file does not exist"
+	@echo "scripts/makefile/hookupdateval.sh file does not exist"
 	@exit 1
 endif
 


### PR DESCRIPTION
…commits at once

TLDR: `git show` check content of last commit pushed only so it was replaced by `git diff` to compare current branch and parent branch to get accurate list of changes across all commits