### PR TITLE
Set composer2 in make provision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,8 @@ endif
 	make -s down
 	@echo "Build and run containers..."
 	docker-compose up -d --remove-orphans
+	# Set composer2 as default
+	$(call php-0, ln -fs composer2 /usr/bin/composer)
 	$(call php-0, apk add --no-cache tzdata $(ADD_PHP_EXT))
 	# Set up timezone
 	$(call php-0, cp /usr/share/zoneinfo/Europe/Paris /etc/localtime)


### PR DESCRIPTION
Similarly to alpine packages, we need to set composer2 in `make provision` cause `make all_ci` won't run `make back` but we still need composer2 to be set.