### PR TITLE
Properly remove migrate generator config objects.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,9 +126,8 @@ ifneq ($(strip $(MG_MODULES)),)
 	$(call php, drush en $(MG_MODULES) -y)
 	$(call php, drush migrate_generator:generate_migrations /var/www/html/content --update)
 	$(call php, drush migrate:import --all --group=migrate_generator_group)
+	$(call php, drush migrate_generator:clean_migrations migrate_generator_group)
 	$(call php, drush pmu $(MG_MODULES) -y)
-	@echo "Deleting configs created by migrate_generator..." # https://dgo.to/3205125
-	for i in $(shell docker-compose exec --user $(CUID):$(CGID) php drush config:status --state=Any --format=list | grep -E 'migrate_plus.migration.migrate_generator|migrate_plus.migration_group.migrate_generator_group') ; do $(call php, drush config:delete -y $$i) ; done
 endif
 
 local-settings:

--- a/composer.json
+++ b/composer.json
@@ -176,6 +176,9 @@
       "drupal/gin_login": {
         "Add missing schema for gin_login": "https://www.drupal.org/files/issues/2021-01-13/gin_login-config_schema-3192526-8.patch"
       },
+      "drupal/migrate_generator": {
+        "Ability to remove config of generated migrations": "https://git.drupalcode.org/project/migrate_generator/commit/20dc65e.patch"
+      },
       "drupal/upgrade_status": {
         "Exclude node_modules from scan": "https://www.drupal.org/files/issues/2021-03-04/3162997-20.patch"
       }


### PR DESCRIPTION
Last line in `make content` attempts to remove the config objects created by migrate generator but fails doing so. On my tests I see on console output `for i in  ; do $(call php, drush config:delete -y $$i) ; done` so looks like the list of config objects isn't passed to the upper level script. Then, I split the code by 1st saving the list of config objects in a variable and then using the new variable to iterate for removal.

On vanilla SDC setup the config objects get removed when `migrate_plus` module gets uninstalled in line `$(call php, drush pmu $(MG_MODULES) -y)` so the issue isn't noticed but some projects require `migrate_plus` to remain enabled. Therefore, you can test the issue by setting `MG_MODULES=migrate_generator` in `.env` file and verify these code changes fix it.
