### PR TITLE
Document make diff and unify output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,8 +176,8 @@ endif
 
 ## Output diff between local and versioned files
 diff:
-	diff --color .env .env.default || true; echo ""
-	diff --color docker/docker-compose.override.yml docker/docker-compose.override.yml.default || true; echo ""
+	diff -u0 --color .env .env.default || true; echo ""
+	diff -u0 --color docker/docker-compose.override.yml docker/docker-compose.override.yml.default || true; echo ""
 
 
 ## Run shell in PHP container as regular user

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ networks:
 * `make clean` - Totally remove project build folder, files, docker containers and network.
 * `make si` - Install/reinstall site.
 * `make info` - Show project services IP addresses.
+* `make diff` - Show changes in overrides (needs local `diff` command).
 * `make exec` - `docker exec` into php container.
 * `make exec0` - `docker exec` into php container as root.
 * `make dev` - Devel + kint setup, and config for Twig debug mode, disable aggregation.


### PR DESCRIPTION
Follow-up to https://github.com/skilld-labs/skilld-docker-container/pull/364

```diff
skilld-docker-container$ make diff
diff -u0 --color .env .env.default || true; echo ""
--- .env	2021-03-11 10:38:12.547573021 +0200
+++ .env.default	2021-03-30 03:32:34.109671848 +0300
@@ -2 +2 @@
-COMPOSE_PROJECT_NAME=sdc
+COMPOSE_PROJECT_NAME=projectname
@@ -4 +4,2 @@
-MODULES=project_default_content better_normalizers default_content hal serialization
+DC_MODULES=project_default_content better_normalizers default_content hal serialization
+MG_MODULES=migrate_generator migrate migrate_plus migrate_source_csv migrate_tools

diff -u0 --color docker/docker-compose.override.yml docker/docker-compose.override.yml.default || true; echo ""
--- docker/docker-compose.override.yml	2021-04-22 04:32:52.042085239 +0300
+++ docker/docker-compose.override.yml.default	2021-03-30 03:32:34.113671888 +0300
@@ -17 +17 @@
-  <<: *service-newrelic
+#  <<: *service-newrelic
@@ -26 +25,0 @@
-#      NEW_RELIC_LICENSE_KEY: eu01xxfcd80284a580148d24afa86247a587NRAL
@@ -43,3 +42,3 @@
-#      BLACKFIRE_SERVER_ID: c191be4a-b8c3-41d9-b4f9-bdaa67ccdc88
-#      BLACKFIRE_SERVER_TOKEN: 1201f7339c743b4e9974e327863b477474faf979c029a8b45b7727139474269d
-#      BLACKFIRE_LOG_LEVEL: 4
+#      BLACKFIRE_SERVER_ID: x
+#      BLACKFIRE_SERVER_TOKEN: x
+#      BLACKFIRE_LOG_LEVEL: 1

```