### PR TITLE
Drupal 8 is EOL, using version-agniostic sqlite

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -15,11 +15,11 @@ IMAGE_REDIS=redis:5-alpine
 IMAGE_DRIVER=zenika/alpine-chrome
 CLEAR_FRONT_PACKAGES=no
 MAIN_DOMAIN_NAME=docker.localhost
-DB_URL=sqlite:./../.cache/d8.sqlite
+DB_URL=sqlite:./../.cache/db.sqlite
 # Faster but data will be lost on php container recreation
-#DB_URL=sqlite:///dev/shm/d8.sqlite
-#DB_URL=mysql://d8:d8@mysql/d8
-#DB_URL=pgsql://d9:d9root@postgresql/d9
+#DB_URL=sqlite:///dev/shm/db.sqlite
+#DB_URL=mysql://db:db@mysql/db
+#DB_URL=pgsql://db:dbroot@postgresql/db
 # Include path to this folder to your .gitignore if you override it
 DB_DATA_DIR=../.cache
 #DB_DATA_DIR=/dev/shm

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ allfast: | fast provision back front si localize hooksymlink info
 
 ## Update .env to build DB in ram (makes data NOT persistant)
 fast:
-	$(shell sed -i "s|^#DB_URL=sqlite:///dev/shm/d8.sqlite|DB_URL=sqlite:///dev/shm/d8.sqlite|g"  .env)
-	$(shell sed -i "s|^DB_URL=sqlite:./../.cache/d8.sqlite|#DB_URL=sqlite:./../.cache/d8.sqlite|g"  .env)
+	$(shell sed -i "s|^#DB_URL=sqlite:///dev/shm/db.sqlite|DB_URL=sqlite:///dev/shm/db.sqlite|g"  .env)
+	$(shell sed -i "s|^DB_URL=sqlite:./../.cache/db.sqlite|#DB_URL=sqlite:./../.cache/db.sqlite|g"  .env)
 
 ## Provision enviroment
 provision:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 | IMAGE_DRIVER | Image to use for automated testing webdriver | `zenika/alpine-chrome` |
 | ADD_PHP_EXT | Additional php extension to install | - |
 | MAIN_DOMAIN_NAME | Domain name used for traefik | `docker.localhost` |
-| DB_URL | Url to connect to database | `sqlite:///dev/shm/d8.sqlite` |
+| DB_URL | Url to connect to database | `sqlite:///dev/shm/db.sqlite` |
 | DB_DATA_DIR | Full path to database storage | `/dev/shm` |
 | CLEAR_FRONT_PACKAGES | Set it to `no` to keep `/node_nodules` directory in theme after `make front` task to save build time. | yes |
 | RA_BASIC_AUTH | username:hashed-password format defining BasicAuth in Traefik. Password hashed using `htpasswd -nibB username password!` as [described here](https://doc.traefik.io/traefik/middlewares/basicauth/#general) | - |
@@ -86,7 +86,7 @@
     image: percona:5.7.22
   ...
   ```
-  * Update `.env` file, and set `DB_URL=mysql://d8:d8@mysql/d8`
+  * Update `.env` file, and set `DB_URL=mysql://db:db@mysql/db`
 
 #### Network
 

--- a/docker/docker-compose.override.yml.default
+++ b/docker/docker-compose.override.yml.default
@@ -61,10 +61,10 @@ services:
 #    volumes:
 #      - ${DB_DATA_DIR}/${COMPOSE_PROJECT_NAME}_mysql:/var/lib/mysql:Z
 #    environment:
-#      MYSQL_DATABASE: d8
-#      MYSQL_USER: d8
-#      MYSQL_PASSWORD: d8
-#      MYSQL_ROOT_PASSWORD: d8root
+#      MYSQL_DATABASE: db
+#      MYSQL_USER: db
+#      MYSQL_PASSWORD: db
+#      MYSQL_ROOT_PASSWORD: dbroot
 
 #  postgresql:
 #    <<: *service-defaults
@@ -73,9 +73,9 @@ services:
 #    volumes:
 #      - ${DB_DATA_DIR}/${COMPOSE_PROJECT_NAME}_pgsql:/var/lib/postgresql/data:Z
 #    environment:
-#      POSTGRES_DB: d9
-#      POSTGRES_USER: d9
-#      POSTGRES_PASSWORD: d9root
+#      POSTGRES_DB: db
+#      POSTGRES_USER: db
+#      POSTGRES_PASSWORD: dbroot
 #      PGDATA: /var/lib/postgresql/data
 
   mailhog:

--- a/scripts/makefile/tests.mk
+++ b/scripts/makefile/tests.mk
@@ -66,7 +66,6 @@ endif
 ## Validate composer.json file
 compval:
 	@echo "Composer.json validation..."
-	# Can't use --strict cause we need dev versions for d9 compatibility
 	@docker run --rm -v $(CURDIR):/mnt -w /mnt $(IMAGE_PHP) composer validate
 
 ## Validate watchdog logs


### PR DESCRIPTION
I see no reason to use version-specific db-credentials