### PR TITLE
Add changes according to latest version of migrate_generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,8 @@ endif
 ifneq ($(strip $(MG_MODULES)),)
 	$(call php, drush en $(MG_MODULES) -y)
 	$(call php, drush migrate_generator:generate_migrations /var/www/html/content --update)
-	$(call php, drush migrate:import --all --group=migrate_generator_group)
-	$(call php, drush migrate_generator:clean_migrations migrate_generator_group)
+	$(call php, drush migrate:import --all --group=mgg)
+	$(call php, drush migrate_generator:clean_migrations mgg)
 	$(call php, drush pmu $(MG_MODULES) -y)
 endif
 

--- a/composer.json
+++ b/composer.json
@@ -115,9 +115,6 @@
       },
       "drupal/default_content": {
         "Do not reimport existing entities": "https://www.drupal.org/files/issues/do_not_reimport-2698425-56.patch"
-      },
-      "drupal/migrate_generator": {
-        "Ability to remove config of generated migrations": "https://git.drupalcode.org/project/migrate_generator/commit/20dc65e.patch"
       }
     }
   }


### PR DESCRIPTION
Changes according to latest release of migrate_generator
https://www.drupal.org/project/migrate_generator/releases/8.x-1.1-alpha2

- removed "Ability to remove config of generated migrations" patch from composer.json
- updated default migration group name to **mgg**