### PR TITLE
Fixing nasty OSX bug where docker mount root dir

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,6 @@ sniffers:compose:
   stage: sniffers
   script:
     - composer -vvv -V
-    # Can't use --strict cause we need dev versions for d9 compatibility
     - time composer validate --profile
   only:
     - branches

--- a/Makefile
+++ b/Makefile
@@ -21,21 +21,22 @@ LOCAL_GID := $(shell id -g)
 CUID ?= $(LOCAL_UID)
 CGID ?= $(LOCAL_GID)
 
+# Define current directory only once
+CURDIR=$(shell pwd)
+
 # Define network name.
 COMPOSE_NET_NAME := $(COMPOSE_PROJECT_NAME)_front
 
 SDC_SERVICES=$(shell docker-compose config --services)
 # Determine database data directory if defined
-DB_MOUNT_DIR=$(shell cd docker && realpath $(DB_DATA_DIR))/
+DB_MOUNT_DIR=$(shell echo $(CURDIR))/$(shell basename $(DB_DATA_DIR))
 ifeq ($(findstring mysql,$(SDC_SERVICES)),mysql)
-	DB_MOUNT_DIR=$(shell cd docker && realpath $(DB_DATA_DIR))/$(COMPOSE_PROJECT_NAME)_mysql
+	DB_MOUNT_DIR=$(shell echo $(CURDIR))/$(shell basename $(DB_DATA_DIR))/$(COMPOSE_PROJECT_NAME)_mysql
 endif
 ifeq ($(findstring postgresql,$(SDC_SERVICES)),postgresql)
-	DB_MOUNT_DIR=$(shell cd docker && realpath $(DB_DATA_DIR))/$(COMPOSE_PROJECT_NAME)_pgsql
+	DB_MOUNT_DIR=$(shell echo $(CURDIR))/$(shell basename $(DB_DATA_DIR))/$(COMPOSE_PROJECT_NAME)_pgsql
 endif
 
-# Define current directory only once
-CURDIR=$(shell pwd)
 
 # Execute php container as regular user
 php = docker-compose exec -T --user $(CUID):$(CGID) php ${1}
@@ -134,7 +135,7 @@ ifneq ("$(wildcard settings/settings.local.php)","")
 	$(call php, drush cr)
 endif
 
-REDIS_IS_INSTALLED := $(shell grep "redis.connection" web/sites/default/settings.php | tail -1 | wc -l || echo "0")
+REDIS_IS_INSTALLED := $(shell grep "redis.connection" web/sites/default/settings.php 2> /dev/null | tail -1 | wc -l || echo "0")
 redis-settings:
 ifeq ($(REDIS_IS_INSTALLED), 1)
 	@echo "Redis settings already installed, nothing to do"
@@ -200,8 +201,10 @@ DIRS = web/core web/libraries web/modules/contrib web/profiles/contrib web/sites
 ## Totally remove project build folder, docker containers and network
 clean: info
 	make -s down
+ifdef CURDIR
 	$(eval SCAFFOLD = $(shell docker run --rm -v $(CURDIR):/mnt -w /mnt --user $(CUID):$(CGID) $(IMAGE_PHP) composer run-script list-scaffold-files | grep -P '^(?!>)'))
 	@docker run --rm --user 0:0 -v $(CURDIR):/mnt -w /mnt -e RMLIST="$(addprefix web/,$(SCAFFOLD)) $(DIRS)" $(IMAGE_PHP) sh -c 'for i in $$RMLIST; do rm -fr $$i && echo "Removed $$i"; done'
+endif
 ifdef DB_MOUNT_DIR
 	@echo "Clean-up database data from $(DB_MOUNT_DIR) ..."
 	docker run --rm --user 0:0 -v $(shell dirname $(DB_MOUNT_DIR)):/mnt $(IMAGE_PHP) sh -c "rm -fr /mnt/`basename $(DB_MOUNT_DIR)`"

--- a/scripts/makefile/system-detection.mk
+++ b/scripts/makefile/system-detection.mk
@@ -24,7 +24,11 @@ else
 	    SYSTEM_OS = 'LINUX'
     endif
     ifeq ($(UNAME_S),Darwin)
-	    SYSTEM_OS = 'OS_X'
+        SYSTEM_OS = 'OS_X'
+        CUID=1000
+        CGID=1000
+        PHP_VERSION=7
+        COMPOSE_HTTP_TIMEOUT=1024
     endif
     UNAME_P := $(shell uname -p)
     ifeq ($(UNAME_P),x86_64)


### PR DESCRIPTION
Before : 
```
/bin/sh: realpath: command not found
make -s down
Removing network & containers for skilld
[+] Running 4/4
 ⠿ Container skilld_web   Removed                                                                                                                                0.4s
 ⠿ Container skilld_mail  Removed                                                                                                                                0.3s
 ⠿ Container skilld_php   Removed                                                                                                                                0.4s
 ⠿ Network skilld_front   Removed                                                                                                                                0.1s
CURDIR=/Users/skilld/Sources/ski-platform/roles/techs/services/skilld-landing/files
#
#@docker run --rm --user 0:0 -v /Users/skilld/Sources/ski-platform/roles/techs/services/skilld-landing/files:/mnt -w /mnt -e RMLIST=" web/core web/libraries web/modules/contrib web/profiles/contrib web/sites web/themes/contrib vendor" skilldlabs/php:74-fpm sh -c 'for i in $RMLIST; do rm -fr $i && echo "Removed $i"; done'
Clean-up database data from / ...
docker run --rm --user 0:0 -v /:/mnt skilldlabs/php:74-fpm sh -c "rm -fr /mnt/`basename /`"
rm: can't remove '/mnt/var/run/linuxkit-external-logging.sock': Resource busy
rm: can't remove '/mnt/var/run/linuxkit-containerd/containerd.sock': Resource busy
rm: can't remove '/mnt/var/log': Resource busy
```

After : 
```
CURDIR=/Users/skilld/Sources/ski-platform/roles/techs/services/skilld-landing/files
#@docker run --rm --user 0:0 -v /Users/skilld/Sources/ski-platform/roles/techs/services/skilld-landing/files:/mnt -w /mnt -e RMLIST=" web/core web/libraries web/modules/contrib web/profiles/contrib web/sites web/themes/contrib vendor" skilldlabs/php:74-fpm sh -c 'for i in $RMLIST; do rm -fr $i && echo "Removed $i"; done'
Clean-up database data from /Users/skilld/Sources/ski-platform/roles/techs/services/skilld-landing/files/.cache ...
docker run --rm --user 0:0 -v /Users/skilld/Sources/ski-platform/roles/techs/services/skilld-landing/files:/mnt skilldlabs/php:74-fpm sh -c "rm -fr /mnt/`basename /Users/skilld/Sources/ski-platform/roles/techs/services/skilld-landing/files/.cache`"

```