### PR TITLE
Move `make content` after local settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,9 @@ else
 endif
 	$(call php, drush user:create "$(TESTER_NAME)")
 	$(call php, drush user:role:add "$(TESTER_ROLE)" "$(TESTER_NAME)")
-	make content
 	make -s local-settings
 	#make -s redis-settings
+	make content	
 
 content:
 ifneq ($(strip $(DC_MODULES)),)


### PR DESCRIPTION
When we're using private folder for some file fields, we have `Unable to find the wrapper "private" - did you forget to enable it when you configured PHP? FileSystem.php:560` error during content migration, as private folder is not defined yet.
 
Need to move `make content` after applying local settings