### PR TITLE
Remove composer 1.x remains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,6 @@ endif
 	make -s down
 	@echo "Build and run containers..."
 	docker-compose up -d --remove-orphans
-	# Set composer2 as default
-	$(call php-0, ln -fs composer2 /usr/bin/composer)
 ifneq ($(strip $(ADDITIONAL_PHP_PACKAGES)),)
 	$(call php-0, apk add --no-cache $(ADDITIONAL_PHP_PACKAGES))
 endif

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ networks:
 * `make front` - Builds frontend tasks.
 * `make lint` - Runs frontend linters.
 * `make storybook` - Runs storybook in current theme.
-* `make blackfire` - Adds and enables blackfire.io php extension, needs [configuration](https://blackfire.io/docs/configuration/php) in docker-composer override.yml.
+* `make blackfire` - Adds and enables blackfire.io php extension, needs [configuration](https://blackfire.io/docs/configuration/php) in docker-compose.override.yml.
 * `make newrelic` - Adds and enables newrelic.com php extension, needs [configuration](https://docs.newrelic.com/docs/agents/php-agent/getting-started/introduction-new-relic-php#configuration) `NEW_RELIC_LICENSE_KEY` environment variable defined with valid license key.
 * `make xdebug (on|off|status)` - Enable, disable or report status of [Xdebug](https://xdebug.org/docs/) PHP extension.
 


### PR DESCRIPTION
Composer 1 no longer shipped with PHP 8.x images

Ref https://github.com/skilld-labs/docker-php/blob/c96f7138a685bcd1536527b0327e60fea9241de1/php8/Dockerfile#L82-L89