### PR TITLE
Remove traefik 1.x and fix make info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,12 +157,12 @@ info:
 	$(info )
 	$(info Containers for "$(COMPOSE_PROJECT_NAME)" info:)
 	$(eval CONTAINERS = $(shell docker ps -f name=$(COMPOSE_PROJECT_NAME) --format "{{ .ID }}" -f 'label=traefik.enable=true'))
-	$(foreach CONTAINER, $(CONTAINERS),$(info http://$(shell printf '%-19s \n'  $(shell docker inspect --format='{{(index .NetworkSettings.Networks "$(COMPOSE_NET_NAME)").IPAddress}}:{{index .Config.Labels "traefik.port"}} {{range $$p, $$conf := .NetworkSettings.Ports}}{{$$p}}{{end}} {{.Name}}' $(CONTAINER) | rev | sed "s/pct\//,pct:/g" | sed "s/,//" | rev | awk '{ print $0}')) ))
+	$(foreach CONTAINER, $(CONTAINERS),$(info http://$(shell printf '%-19s \n'  $(shell docker inspect --format='{{(index .NetworkSettings.Networks "$(COMPOSE_NET_NAME)").IPAddress}}:{{index .Config.Labels "sdc.port"}} {{range $$p, $$conf := .NetworkSettings.Ports}}{{$$p}}{{end}} {{.Name}}' $(CONTAINER) | rev | sed "s/pct\//,pct:/g" | sed "s/,//" | rev | awk '{ print $0}')) ))
 	$(info )
 ifdef REVIEW_DOMAIN
 	$(eval BASE_URL := $(MAIN_DOMAIN_NAME))
 else
-	$(eval BASE_URL := $(shell docker inspect --format='{{(index .NetworkSettings.Networks "$(COMPOSE_NET_NAME)").IPAddress}}:{{index .Config.Labels "traefik.port"}}' $(COMPOSE_PROJECT_NAME)_web))
+	$(eval BASE_URL := $(shell docker inspect --format='{{(index .NetworkSettings.Networks "$(COMPOSE_NET_NAME)").IPAddress}}:{{index .Config.Labels "sdc.port"}}' $(COMPOSE_PROJECT_NAME)_web))
 endif
 	$(info Login as System Admin: http://$(shell printf '%-19s \n'  $(shell echo "$(BASE_URL)"$(shell $(call php, drush user:login --name="$(ADMIN_NAME)" /admin/content/ | awk -F "default" '{print $$2}')))))
 	$(info Login as Contributor: http://$(shell printf '%-19s \n'  $(shell echo "$(BASE_URL)"$(shell $(call php, drush user:login --name="$(TESTER_NAME)" /admin/content/ | awk -F "default" '{print $$2}')))))

--- a/docker/docker-compose.override.yml.default
+++ b/docker/docker-compose.override.yml.default
@@ -86,12 +86,8 @@ services:
     image: skilldlabs/mailhog
     container_name: "${COMPOSE_PROJECT_NAME}_mail"
     labels:
+      - 'sdc.port=8025'
       - 'traefik.enable=true'
-      # Treafik 1.x
-      - 'traefik.backend=${MAIN_DOMAIN_NAME}_mail'
-      - 'traefik.frontend.rule=Host:mail-${MAIN_DOMAIN_NAME}'
-      - 'traefik.frontend.redirect.entryPoint=https'
-      - 'traefik.port=8025'
       # Treafik 2.x
       - 'traefik.http.routers.mailhog-${COMPOSE_PROJECT_NAME}.rule=Host(`mail-${MAIN_DOMAIN_NAME}`)'
       - 'traefik.http.routers.mailhog-${COMPOSE_PROJECT_NAME}.tls.certresolver=dns'
@@ -109,12 +105,8 @@ services:
 #    volumes:
 #     - ./nginx/ssl:/etc/nginx/ssl:Z
     labels:
+      - 'sdc.port=80'
       - 'traefik.enable=true'
-      # Treafik 1.x
-      - 'traefik.backend=${MAIN_DOMAIN_NAME}_web'
-      - 'traefik.frontend.rule=Host:${MAIN_DOMAIN_NAME}'
-      - 'traefik.frontend.redirect.entryPoint=https'
-      - 'traefik.port=80'
       # Treafik 2.x
       - 'traefik.http.routers.nginx-${COMPOSE_PROJECT_NAME}.rule=Host(`${MAIN_DOMAIN_NAME}`)'
       - 'traefik.http.routers.nginx-${COMPOSE_PROJECT_NAME}.tls.certresolver=dns'
@@ -132,12 +124,8 @@ services:
 #     volumes:
 #      - ./apache/ssl:/etc/apache2/ssl:Z
 #    labels:
+#      - 'sdc.port=80'
 #      - 'traefik.enable=true'
-#      # Treafik 1.x
-#      - 'traefik.backend=${MAIN_DOMAIN_NAME}_web'
-#      - 'traefik.frontend.rule=Host:${MAIN_DOMAIN_NAME}'
-#      - 'traefik.frontend.redirect.entryPoint=https'
-#      - 'traefik.port=80'
 #      # Treafik 2.x
 #      - 'traefik.http.routers.apache-${COMPOSE_PROJECT_NAME}.rule=Host(`${MAIN_DOMAIN_NAME}`)'
 #      - 'traefik.http.routers.apache-${COMPOSE_PROJECT_NAME}.tls.certresolver=dns'
@@ -148,12 +136,8 @@ services:
 
 #  solr:
 #    labels:
+#      - 'sdc.port=8983'
 #      - 'traefik.enable=true'
-#      # Treafik 1.x
-#      - 'traefik.backend=${MAIN_DOMAIN_NAME}_solr'
-#      - 'traefik.frontend.rule=Host:solr-${MAIN_DOMAIN_NAME}'
-#      - 'traefik.frontend.redirect.entryPoint=https'
-#      - 'traefik.port=8983'
 #      # Treafik 2.x
 #      - 'traefik.http.routers.solr-${COMPOSE_PROJECT_NAME}.rule=Host(`solr-${MAIN_DOMAIN_NAME}`)'
 #      - 'traefik.http.routers.solr-${COMPOSE_PROJECT_NAME}.tls.certresolver=dns'


### PR DESCRIPTION
`traefik.port` is no longer available, add custom label `sdc.port`

it has collision to merge with https://github.com/skilld-labs/skilld-docker-container/pull/429