### PR TITLE
#438 - Remove dependency to Webmozart\PathUtil\Path

### DIFF
--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -12,7 +12,7 @@ use Composer\Semver\Comparator;
 use Drupal\Core\Site\Settings;
 use DrupalFinder\DrupalFinder;
 use Symfony\Component\Filesystem\Filesystem;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * Class ScriptHandler


### PR DESCRIPTION
PR to address #438 (based on this change https://github.com/drupal-composer/drupal-project/pull/619/files)

One note though : I tried without adding `use Symfony\Component\Filesystem\Path;` and install seemed to be still working, worth digging a bit, if useless or no (I see usage of "Path" a bit later in ScriptHandler.php..?)