### PR TITLE
Require Drush 12 and fix import of locale

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "drupal/imagemagick": "^3.4",
     "drupal/migrate_generator": "^1.5",
     "drupal/seven": "^1.0",
-    "drush/drush": "^11.5 || ^12.0@rc",
+    "drush/drush": "^12.0",
     "skilldlabs/drupal-cleanup": "^1",
     "skilldlabs/druxxy": "dev-main"
   },
@@ -121,7 +121,7 @@
     },
     "patches": {
       "drush/drush": {
-        "Import multiple custom translation po files": "https://patch-diff.githubusercontent.com/raw/drush-ops/drush/pull/4251.patch"
+        "Import multiple custom translation po files": "https://github.com/drush-ops/drush/pull/5569.patch"
       },
       "drupal/default_content": {
         "Do not reimport existing entities": "https://www.drupal.org/files/issues/2022-07-29/default_content-fix-uuid-duplicate-entry-2698425.patch"


### PR DESCRIPTION
- ~command `migrate:import` now using `--tags` but it's not defined~ https://github.com/skilld-labs/skilld-docker-container/commit/bf5f46ec82503d91cafa9e1a7be87f595aa06882
- command `locale:import-all` ported as patch