### PR TITLE
Replace MailHog with MailPit #449

### DIFF
--- a/docker/docker-compose.override.yml.default
+++ b/docker/docker-compose.override.yml.default
@@ -93,7 +93,7 @@ services:
 
   mailhog:
     <<: *service-defaults
-    image: skilldlabs/mailhog
+    image: axllent/mailpit
     container_name: "${COMPOSE_PROJECT_NAME}_mail"
     labels:
       - 'sdc.port=8025'

--- a/settings/settings.local.php
+++ b/settings/settings.local.php
@@ -10,3 +10,6 @@
 // Global
 $settings['file_private_path'] = '../private-files';
 
+// Sendmail command for symfony_mailer.
+$settings['mailer_sendmail_commands'][] = ini_get('sendmail_path');
+$config['symfony_mailer.mailer_transport.sendmail']['configuration']['query']['command'] = ini_get('sendmail_path') ;


### PR DESCRIPTION
Used mailpit https://mailpit.axllent.org/ instead on Mailhog

Also updated **settings.local.php** to have proper symfony_mailer configuration for sendmail