### PR TITLE
Modernize compose and unit reload

### DIFF
--- a/docker/docker-compose.override.yml.default
+++ b/docker/docker-compose.override.yml.default
@@ -1,5 +1,3 @@
-version: "3.7"
-
 x-service-defaults:
   &service-defaults
   restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 x-service-defaults:
   &service-defaults
   restart: always

--- a/docker/unit.json
+++ b/docker/unit.json
@@ -1,0 +1,115 @@
+{
+  "listeners": {
+    "*:80": {
+      "pass": "routes"
+    }
+  },
+  "routes": [
+    {
+      "match": {
+        "uri": [
+          "!*/.well-known/*",
+          "/vendor/*",
+          "/core/profiles/demo_umami/modules/demo_umami_content/default_content/*",
+          "*.engine",
+          "*.inc",
+          "*.install",
+          "*.make",
+          "*.module",
+          "*.po",
+          "*.profile",
+          "*.sh",
+          "*.theme",
+          "*.tpl",
+          "*.twig",
+          "*.xtmpl",
+          "*.yml",
+          "*/.*",
+          "*/Entries*",
+          "*/Repository",
+          "*/Root",
+          "*/Tag",
+          "*/Template",
+          "*/composer.json",
+          "*/composer.lock",
+          "*/web.config",
+          "*sql",
+          "*.bak",
+          "*.orig",
+          "*.save",
+          "*.swo",
+          "*.swp",
+          "*~"
+        ]
+      },
+      "action": {
+        "return": 404
+      }
+    },
+    {
+      "match": {
+        "uri": [
+          "/core/authorize.php",
+          "/core/install.php",
+          "/core/modules/statistics/statistics.php",
+          "~^/core/modules/system/tests/https?\\.php",
+          "/core/rebuild.php",
+          "/update.php",
+          "/update.php/*"
+        ]
+      },
+      "action": {
+        "pass": "applications/drupal/direct"
+      }
+    },
+    {
+      "match": {
+        "uri": [
+          "!/index.php*",
+          "*.php"
+        ]
+      },
+      "action": {
+        "return": 404
+      }
+    },
+    {
+      "action": {
+        "share": "/var/www/html/web$uri",
+        "fallback": {
+          "pass": "applications/drupal/index"
+        }
+      }
+    }
+  ],
+  "applications": {
+    "drupal": {
+      "type": "php",
+      "processes": {
+        "max": 4,
+        "spare": 2,
+        "idle_timeout": 120
+      },
+      "limits": {
+        "timeout": 300,
+        "requests": 1500
+      },
+      "options": {
+        "admin": {
+          "memory_limit": "1G",
+          "opcache.jit_buffer_size": "20M"
+        }
+      },
+      "targets": {
+        "direct": {
+          "root": "/var/www/html/web/"
+        },
+        "index": {
+          "root": "/var/www/html/web/",
+          "script": "index.php"
+        }
+      }
+    }
+  },
+  "access_log": "/dev/stdout"
+}

--- a/scripts/makefile/reload.sh
+++ b/scripts/makefile/reload.sh
@@ -9,10 +9,15 @@ set -e
 
 socket='--unix-socket /run/control.unit.sock'
 sapi=$(cat /proc/1/comm)
+file=${1:-/var/lib/unit/conf.json}
 
 if [ $sapi == unitd ]; then
-	curl -s -o /dev/null -X PUT --data-binary @/var/lib/unit/conf.json $socket http://localhost/config
-	curl -s -o /dev/null $socket http://localhost/control/applications/drupal/restart
+	if [ -z "$1" ]; then
+		# just reload as no new config passed
+		curl -s -o /dev/null $socket http://localhost/control/applications/drupal/restart
+	else
+		curl -s -o /dev/null -X PUT --data-binary @$file $socket http://localhost/config
+	fi
 elif [ $sapi == php-fpm* ]; then
 	kill -USR2 1;
 else

--- a/scripts/makefile/tests.mk
+++ b/scripts/makefile/tests.mk
@@ -203,7 +203,7 @@ newrelic:
 ifdef NEW_RELIC_LICENSE_KEY
 	$(call php-0, /bin/sh ./scripts/makefile/newrelic.sh $(NEW_RELIC_LICENSE_KEY) '$(COMPOSE_PROJECT_NAME)')
 	$(call php, sed -i -e 's/#  <<: \*service-newrelic/  <<: \*service-newrelic/g' docker/docker-compose.override.yml)
-	docker compose up -d
+	$(call php-0, /bin/sh ./scripts/makefile/reload.sh)
 	@echo "NewRelic PHP extension enabled"
 else
 	@echo "NewRelic install skipped as NEW_RELIC_LICENSE_KEY is not set"


### PR DESCRIPTION
- strictly pass .env to docker compose
- reload of unit should use better config

PS: sometimes new `compose` can't find `.env` file or picks it from wrong location so I decided to settle it independently from default