### PR TITLE
Upgrade docker-phpcs-drupal image

### DIFF
--- a/scripts/makefile/tests.mk
+++ b/scripts/makefile/tests.mk
@@ -9,7 +9,7 @@ tests: | sniffers cinsp drupalrectorval upgradestatusval behat watchdogval statu
 phpcsexec = docker run --rm \
 	-v $(CURDIR)/web/modules/custom:/work/modules \
 	-v $(CURDIR)/web/themes/custom:/work/themes \
-	skilldlabs/docker-phpcs-drupal ${1} -s --colors \
+	skilldlabs/docker-phpcs-drupal:10 ${1} -s --colors \
 	--standard=Drupal,DrupalPractice \
 	--extensions=php,module,inc,install,profile,theme,yml,txt,md,js \
 	--ignore=*.min.js,*.css,libraries/*,dist/*,styleguide/*,README.md,README.txt,node_modules/*,work/themes/**.js,work/themes/**.md \


### PR DESCRIPTION
Used new `skilldlabs/docker-phpcs-drupal:10` image according to updates made from https://projects.skilld.cloud/skilld/ski-contrib/-/issues/374