### PR TITLE
Upgrade Drush to 13.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,10 @@
     "drupal/imagemagick": "^4.0",
     "drupal/migrate_generator": "^2.0",
     "drupal/seven": "^1.0",
-    "drush/drush": "^12.5",
+    "drush/drush": "^13.2",
     "skilldlabs/drupal-cleanup": "^1",
-    "skilldlabs/druxxy": "^1.1"
+    "skilldlabs/druxxy": "^1.1",
+    "webflo/drupal-finder": "^1.3"
   },
   "require-dev": {
     "dmore/behat-chrome-extension": "^1.3",


### PR DESCRIPTION
- 13.0 no longer depend on webflo/drupal-finder
- ScriptHandler using it so added dependency

Related to https://github.com/skilld-labs/skilld-docker-container/pull/464 and https://github.com/skilld-labs/skilld-docker-container/issues/461